### PR TITLE
Pilot: harden Quarto site + RNA-seq workflow page

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,66 @@
+name: Publish Quarto Site
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Render Quarto site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render site
+        run: quarto render
+
+      - name: Verify .nojekyll
+        run: test -f docs/.nojekyll
+
+      - name: Verify archived RNA-seq images
+        run: |
+          test -f docs/_Archived/RNAseq_workflow/img/fastqs.png
+          test -f docs/_Archived/RNAseq_workflow/img/list.png
+          test -f docs/_Archived/RNAseq_workflow/img/outs.png
+          test -f docs/_Archived/RNAseq_workflow/img/multiqc.png
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs
+
+  deploy:
+    name: Deploy Quarto site
+    if: github.event_name == 'push'
+    needs: render
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ dmypy.json
 
 # profiling data
 .prof
+
+/.quarto/
+**/*.quarto_ipynb

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Important Note: This repository is still under development and the information contained within it may change. If you have any feedback or suggestions, feel free to open an issue or reach out to us.**
 
+Browse the tutorial site: [osu-bmbl.github.io/BMBL-analysis-notebooks](https://osu-bmbl.github.io/BMBL-analysis-notebooks/)
+
 ## Purpose
 
 This repository contains a collection of bioinformatics data analysis notebooks focused on providing examples of current best practices in single-cell analysis. The notebooks include both data and code.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,43 @@
+project:
+  type: website
+  output-dir: docs
+  resources:
+    - _Archived/RNAseq_workflow/img/*.png
+  post-render:
+    - bash scripts/ensure-nojekyll.sh
+  render:
+    - index.qmd
+    - rnaseq-workflow.qmd
+
+execute:
+  enabled: false
+
+website:
+  title: "BMBL Analysis Notebooks"
+  site-url: "https://osu-bmbl.github.io/BMBL-analysis-notebooks/"
+  repo-url: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks"
+  navbar:
+    logo: "https://cpb-us-w2.wpmucdn.com/u.osu.edu/dist/0/72768/files/2020/07/bmbl_logo1-300x124.png"
+    right:
+      - text: "RNA-seq Workflow"
+        href: rnaseq-workflow.qmd
+      - icon: github
+        href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks"
+        aria-label: "BMBL Analysis Notebooks on GitHub"
+  sidebar:
+    style: docked
+    search: true
+    contents:
+      - href: index.qmd
+        text: "Home"
+      - href: rnaseq-workflow.qmd
+        text: "RNA-seq Workflow"
+
+format:
+  html:
+    theme: cosmo
+    css: styles.css
+    toc: true
+    code-copy: true
+    code-overflow: wrap
+    smooth-scroll: true

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,41 @@
+---
+title: "BMBL Analysis Notebooks"
+page-layout: full
+---
+
+::: {.hero-panel}
+![](https://cpb-us-w2.wpmucdn.com/u.osu.edu/dist/0/72768/files/2020/07/bmbl_logo1-300x124.png){.hero-logo}
+
+# BMBL Analysis Notebooks
+
+This site turns the repository into a browsable, static reference for bioinformatics workflows. It is designed for readers who already know the assays and analysis ecosystem and want a clearer way to review workflow usage, code, and existing figures.
+
+The current Phase 1 build focuses on a single RNA-seq workflow page so the layout, tone, and navigation pattern can be reviewed before the rest of the catalog is added.
+
+This pilot intentionally uses archived RNA-seq content as a layout and navigation test before the broader site expands in Phase 2.
+:::
+
+::: {.grid}
+::: {.g-col-12 .g-col-lg-8}
+## Purpose
+
+The repository contains practical bioinformatics notebooks and companion files for workflows used by the BMBL lab. This website keeps the materials in the same repo and presents them as a display-only reading experience rather than a runnable tutorial environment.
+:::
+
+::: {.g-col-12 .g-col-lg-4}
+::: {.pilot-card}
+### Featured Workflow
+
+[RNA-seq Workflow](rnaseq-workflow.qmd)
+
+Browse the RNA-seq workflow page for prerequisites, step-by-step usage notes, existing images, and links back to the source files on GitHub.
+:::
+:::
+:::
+
+## What To Expect
+
+- Static pages generated with Quarto
+- Existing prose, code snippets, and committed figures from the repo
+- No live execution, Binder launchers, or in-browser notebook runs
+- A documentation-first layout that will scale to the rest of the repository after pilot review

--- a/rnaseq-workflow.qmd
+++ b/rnaseq-workflow.qmd
@@ -1,0 +1,232 @@
+---
+title: "RNA-seq Workflow"
+subtitle: "Bulk RNA-seq preprocessing and downstream analysis reference"
+---
+
+# What it does
+
+This workflow provides a bulk RNA-seq reference path that starts with preprocessing on the OSC cluster and continues into downstream analysis in R. The materials cover fastq preparation, alignment and quantification submission, count-matrix preparation, PCA, differential expression, volcano plots, and enrichment analyses.
+
+# When to use it
+
+Use this workflow when you already have paired-end bulk RNA-seq data and want a lab-specific guide for moving from raw fastq files to count and metadata tables, then into downstream exploratory and differential expression analyses. It is most useful when you want example commands, expected intermediate files, and template code for common follow-up analysis decisions.
+
+# Prerequisites
+
+- Access to the workflow folder: [`_Archived/RNAseq_workflow`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow)
+- An OSC account and access to the project space described in the preprocessing tutorial
+- R plus the packages listed in [`RNAseq_install_packages.R`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_install_packages.R)
+- Example input tables from [`Example_Data`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Example_Data)
+- The main source files used by this page:
+  - [`RNAseq_Preprocessing_Tutorial.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_Preprocessing_Tutorial.md)
+  - [`RNAseq_Downstream_Analysis.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_Downstream_Analysis.md)
+  - [`downstream_analysis_template.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template.Rmd)
+  - [`downstream_analysis_template_using_limma.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template_using_limma.Rmd)
+  - [`limma_deg.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/limma_deg.Rmd)
+
+# Steps
+
+## Prepare OSC tools, references, and input data
+
+The preprocessing tutorial assumes OSC access and uses shared lab paths for tools and reference genomes. Before submitting jobs, confirm the correct species reference and prepare your fastq files in sample-level folders.
+
+```bash
+/fs/ess/PCON0022/tools
+/fs/ess/PCON0022/tools/genome/Mus_musculus.GRCm38.99
+/fs/ess/PCON0022/tools/genome/Homo_sapiens.GRCh38.99
+```
+
+If you are using the provided example data, the tutorial points to the OSC copy and the local [`Example_Data`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Example_Data) folder so you can compare expected inputs and outputs.
+
+## Organize fastq files and generate `fastq_list.txt`
+
+Each sample should be stored in its own folder, and the preprocessing scripts expect a `fastq_list.txt` with paired-end files and sample names. The provided helper script automates the list construction after you make the preprocessing scripts executable and load the expected OSC modules.
+
+```bash
+chmod +x *
+module load gnu mkl R/4.0.2
+Rscript build_fastq_list.R
+```
+
+::: {.grid}
+::: {.g-col-12 .g-col-lg-6}
+![Example fastq folder layout](_Archived/RNAseq_workflow/img/fastqs.png)
+:::
+::: {.g-col-12 .g-col-lg-6}
+![Example fastq list layout](_Archived/RNAseq_workflow/img/list.png)
+:::
+:::
+
+The relevant preprocessing files live under [`Preprocessing_code`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Preprocessing_code):
+
+- [`build_fastq_list.R`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/build_fastq_list.R)
+- [`run_primary_alignment.sh`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/run_primary_alignment.sh)
+- [`submit_primary_alignment.sh`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/submit_primary_alignment.sh)
+- [`run_quantification.sh`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/run_quantification.sh)
+
+## Submit alignment jobs
+
+The alignment step uses `run_primary_alignment.sh` and expects you to set the working directory, reference genome, and an OSC Slurm header before submission. The tutorial gives this example header as a starting point:
+
+```bash
+#!/usr/bin/bash
+#SBATCH --account PCON0022
+#SBATCH --time=00:30:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=8
+#SBATCH --mem=32GB
+```
+
+After updating the script for your run, submit the alignment jobs from the correct working directory:
+
+```bash
+./submit_primary_alignment.sh
+```
+
+The tutorial notes that this step should produce `alignment_out`, `fastp_out`, and `result` directories, including `.bam`, `.sam`, `.sorted.bam`, and pre-alignment QC outputs.
+
+## Run quantification and create analysis tables
+
+Once alignment jobs finish, submit quantification and then convert the relevant output into `counts.csv` and `meta.csv`. The workflow suggests checking job completion first and then launching the quantification step.
+
+```bash
+squeue -u USERNAME
+sbatch run_quantification.sh
+```
+
+After quantification, the guide expects you to download `out2.txt`, convert it into `counts.csv`, and build a matching `meta.csv` whose sample names align with the count-matrix columns. The example files in [`Example_Data`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Example_Data) show the expected format.
+
+## Optionally generate a MultiQC report
+
+The preprocessing tutorial includes an optional MultiQC pass for summarizing QC outputs. It provides setup commands for a `multiqc` environment and a simple report-generation command from the results directory.
+
+```bash
+ml python
+conda create -n multiqc python=3.8
+source activate multiqc
+pip install multiqc
+multiqc *
+```
+
+::: {.grid}
+::: {.g-col-12 .g-col-lg-6}
+![Quantification result files](_Archived/RNAseq_workflow/img/outs.png)
+:::
+::: {.g-col-12 .g-col-lg-6}
+![Example MultiQC report view](_Archived/RNAseq_workflow/img/multiqc.png)
+:::
+:::
+
+## Load counts, metadata, and required packages for downstream analysis
+
+The downstream templates begin by installing or loading the required packages, reading `counts.csv` and `meta.csv`, removing duplicate gene rows, and filtering low-count genes. The package list in [`RNAseq_install_packages.R`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_install_packages.R) includes the core analysis stack used across the templates, including `DESeq2`, `limma`, `EnhancedVolcano`, `enrichR`, `fgsea`, and `msigdbr`.
+
+```r
+counts <- read.csv("./Example_Data/counts.csv")
+meta <- read.csv("./Example_Data/meta.csv", stringsAsFactors = FALSE)
+colnames(meta)[1] <- "sample_id"
+colnames(meta)[2] <- "group"
+keep <- rowSums(counts) >= 50
+counts <- counts[keep, ]
+```
+
+The Markdown walkthrough calls out a few user-adjustable parameters at this stage, especially the low-count filtering threshold and datatable page length for metadata inspection.
+
+## Choose a downstream analysis path and inspect PCA
+
+The repository includes both a DESeq2-based template and a limma-based template. Both workflows use the same `counts.csv` and `meta.csv` handoff, but they differ in the modeling code used for differential expression.
+
+For PCA, the downstream guide highlights that the grouping variable should be chosen intentionally based on the biological question, such as time, treatment, or the workflow's default `group` column.
+
+```r
+pcaData <- plotPCA(vsd, intgroup = c("time"), returnData = TRUE)
+```
+
+```r
+pcaData <- plotPCA(vsd, intgroup = c("treatment"), returnData = TRUE)
+```
+
+## Define differential expression comparisons
+
+The downstream workflow emphasizes that defining the comparison groups is one of the most important setup choices in the analysis. The DESeq2 template uses a contrast on the `group` variable, while the limma template builds a design matrix and contrast matrix from metadata levels.
+
+```r
+this_groups <- c("group_1", "group_2")
+```
+
+```r
+res <- results(dds, contrast = c("group", "NCH3", "NCH1"))
+write.csv(res, "./result/Group1_vs_Group2.csv")
+```
+
+```r
+stopifnot(all(meta$sample_id == colnames(counts)))
+contrast.matrix <- makeContrasts(
+  paste0(levels(group)[1], "-", levels(group)[2]),
+  levels = design
+)
+```
+
+## Review volcano plots and enrichment results
+
+For volcano plots, the tutorial shows example cutoffs for adjusted p-value and log2 fold change and notes that these should be adapted to the experiment. The downstream guide then moves into two enrichment patterns: over-representation analysis with `enrichR` and gene set enrichment analysis with `fgsea`.
+
+```r
+EnhancedVolcano(
+  res,
+  lab = rownames(res),
+  x = "log2FoldChange",
+  y = "padj",
+  pCutoff = 0.05,
+  FCcutoff = 1.5
+)
+```
+
+```r
+dbs <- c(
+  "GO_Molecular_Function_2018",
+  "GO_Cellular_Component_2018",
+  "GO_Biological_Process_2018",
+  "KEGG_2019_Human"
+)
+```
+
+If the data are from mouse, the guide notes that the KEGG database entry should be switched to `KEGG_2019_Mouse`.
+
+## Run fgsea with the appropriate database and permutation count
+
+The fgsea section uses `msigdbr` or a saved qsave object to load gene sets, then runs `fgsea` with an explicit permutation count. The source templates show both GO Biological Process and KEGG-style examples for the enrichment stage.
+
+```r
+if (!file.exists("../all_gene_sets_human.qsave")) {
+  all_gene_sets <- msigdbr(species = "human")
+  qs::qsave(all_gene_sets, "all_gene_sets_human.qsave")
+} else {
+  all_gene_sets <- qs::qread("../all_gene_sets_human.qsave")
+}
+```
+
+```r
+fgseaRes <- fgsea(pathways = m_list, stats = res_gsea, nperm = 1000)
+```
+
+The main downstream source files for full code context are:
+
+- [`RNAseq_Downstream_Analysis.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_Downstream_Analysis.md)
+- [`downstream_analysis_template.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template.Rmd)
+- [`downstream_analysis_template_using_limma.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template_using_limma.Rmd)
+- [`limma_deg.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/limma_deg.Rmd)
+
+# Gotchas / notes
+
+- This workflow assumes OSC-specific paths, module loads, and Slurm submission patterns, so cluster and filesystem details may need to be adapted for another environment.
+- Make sure the species reference and downstream database choice match your dataset, especially for human-versus-mouse KEGG and gene-set resources.
+- `counts.csv` and `meta.csv` need to stay aligned; sample identifiers in metadata should match the count-matrix columns before differential expression begins.
+- The low-count filter (`keep`) is intentionally adjustable and should be tuned to the dataset rather than treated as a fixed universal threshold.
+- PCA interpretation depends on the `intgroup` you choose, and the volcano plot cutoffs shown in the templates are example defaults rather than mandatory settings.
+- In the limma template, the contrast matrix is derived from metadata levels, so confirm that factor levels and group ordering reflect the comparison you actually want.
+- The number of permutations in `fgsea` is also a tuning decision; higher values can improve granularity at the cost of compute time.
+
+# View source on GitHub
+
+[📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow)

--- a/scripts/ensure-nojekyll.sh
+++ b/scripts/ensure-nojekyll.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p docs
+touch docs/.nojekyll

--- a/styles.css
+++ b/styles.css
@@ -22,7 +22,7 @@ body {
   background:
     linear-gradient(180deg, var(--osu-white) 0%, var(--osu-gray-light-90) 100%);
   color: var(--osu-gray-dark-80);
-  font-family: "Source Serif 4", Georgia, serif;
+  font-family: "Atkinson Hyperlegible", "Trebuchet MS", sans-serif;
 }
 
 .navbar {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,158 @@
+@import url("https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&display=swap");
+
+:root {
+  --osu-scarlet: #ba0c2f;
+  --osu-scarlet-dark: #70071c;
+  --osu-scarlet-deep: #4a0513;
+  --osu-gray: #a7b1b7;
+  --osu-gray-light-40: #cfd4d8;
+  --osu-gray-light-60: #dfe3e5;
+  --osu-gray-light-80: #eff1f2;
+  --osu-gray-light-90: #f6f7f8;
+  --osu-gray-dark-20: #868e92;
+  --osu-gray-dark-40: #646a6e;
+  --osu-gray-dark-60: #3f4443;
+  --osu-gray-dark-80: #212325;
+  --osu-white: #ffffff;
+  --site-border: rgba(63, 68, 67, 0.12);
+  --site-shadow: rgba(33, 35, 37, 0.08);
+}
+
+body {
+  background:
+    linear-gradient(180deg, var(--osu-white) 0%, var(--osu-gray-light-90) 100%);
+  color: var(--osu-gray-dark-80);
+  font-family: "Source Serif 4", Georgia, serif;
+}
+
+.navbar {
+  background: rgba(255, 255, 255, 0.96);
+  border-bottom: 1px solid var(--site-border);
+  backdrop-filter: blur(10px);
+}
+
+.navbar-brand,
+.nav-link,
+.sidebar-title,
+.sidebar-item-text,
+.quarto-title-meta-heading,
+.menu-text {
+  font-family: "Atkinson Hyperlegible", "Trebuchet MS", sans-serif;
+}
+
+.hero-panel {
+  padding: 2.5rem;
+  margin: 1.2rem 0 2rem;
+  border: 1px solid var(--site-border);
+  border-radius: 1.6rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(246, 247, 248, 0.98));
+  box-shadow: 0 20px 50px var(--site-shadow);
+}
+
+.hero-panel h1,
+.pilot-card h3,
+h1,
+h2,
+h3 {
+  font-family: "Atkinson Hyperlegible", "Avenir Next", sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.hero-logo {
+  max-width: 210px;
+  margin-bottom: 1.2rem;
+}
+
+.pilot-card {
+  height: 100%;
+  padding: 1.4rem;
+  border: 1px solid var(--site-border);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(180deg, var(--osu-white), var(--osu-gray-light-90));
+  box-shadow: 0 16px 36px rgba(33, 35, 37, 0.06);
+}
+
+.pilot-card a,
+a {
+  color: var(--osu-scarlet);
+}
+
+a:hover,
+a:focus,
+.nav-link:hover,
+.nav-link:focus,
+.sidebar-link:hover,
+.sidebar-link:focus {
+  color: var(--osu-scarlet-dark);
+}
+
+.callout.callout-note {
+  border-left-color: var(--osu-scarlet);
+  background: var(--osu-gray-light-90);
+}
+
+.sidebar {
+  background: rgba(246, 247, 248, 0.88);
+  border-right: 1px solid var(--site-border);
+}
+
+.sidebar .active,
+.sidebar .sidebar-link.active,
+.sidebar nav[role="doc-toc"] a.active,
+.nav-link.active,
+.menu-text:hover {
+  color: var(--osu-scarlet);
+}
+
+.quarto-title-block .quarto-title-banner {
+  background:
+    linear-gradient(135deg, rgba(246, 247, 248, 0.98), rgba(223, 227, 229, 0.95));
+  color: var(--osu-gray-dark-80);
+}
+
+.quarto-title-block .subtitle {
+  color: var(--osu-gray-dark-40);
+}
+
+.code-copy-button {
+  border-radius: 999px;
+  color: var(--osu-scarlet);
+}
+
+img {
+  border-radius: 1rem;
+  box-shadow: 0 12px 32px rgba(33, 35, 37, 0.08);
+}
+
+pre,
+.sourceCode {
+  border: 1px solid rgba(167, 177, 183, 0.28);
+  border-radius: 1rem;
+}
+
+.quarto-grid-item,
+.quarto-title-meta,
+.table,
+.callout {
+  border-color: var(--site-border);
+}
+
+.navbar .nav-link,
+.sidebar .sidebar-item-text,
+.toc-actions,
+#TOC a {
+  color: var(--osu-gray-dark-60);
+}
+
+#TOC a:hover,
+#TOC a.active {
+  color: var(--osu-scarlet);
+}
+
+@media (max-width: 991px) {
+  .hero-panel {
+    padding: 1.6rem;
+  }
+}


### PR DESCRIPTION
## Summary

This PR revises the Phase 1 Quarto pilot for the BMBL analysis notebooks site, using `INTERN_TASK_quarto_tutorial_site.md` as the primary spec.

The pilot remains intentionally limited in scope:
- one landing page
- one RNA-seq workflow page
- display-only rendering
- no notebook execution
- no Binder / Colab / WebR / in-browser run buttons

This revision focuses on addressing review feedback and making the pilot safer for production deployment on GitHub Pages.

## What changed

- made `_Archived/RNAseq_workflow/img/*.png` explicit Quarto site resources
- added a dedicated GitHub Pages workflow for the Quarto site
- added PR-time render validation and kept deploy on push to `master` / `main`
- added explicit checks for:
  - successful Quarto render
  - `docs/.nojekyll`
  - archived RNA-seq image assets in `docs/_Archived/RNAseq_workflow/img/`
- restored a single-source `.nojekyll` post-render script
- loaded the custom fonts used by the site stylesheet
- switched body text to sans-serif after local visual review for a cleaner, more modern documentation feel
- fixed the `res` / `result` inconsistency in the illustrative RNA-seq code snippet
- added a small landing-page note clarifying that the current pilot uses archived RNA-seq content as a Phase 1 layout/navigation test
- added a visible link to the live tutorial site near the top of `README.md`

## Why

The main goal of this revision is to close the biggest production risk identified in review: images referenced from `_Archived/` can appear fine locally but fail on a deployed site if resource copying is not handled explicitly.

This PR also makes the pilot easier to validate before merge by adding a render-only PR check, while preserving the task-file constraints for Phase 1.

## Validation

Local verification completed:
- `quarto render` succeeds
- site remains `execute: enabled: false`
- `docs/.nojekyll` is created
- expected archived RNA-seq images are present:
  - `docs/_Archived/RNAseq_workflow/img/fastqs.png`
  - `docs/_Archived/RNAseq_workflow/img/list.png`
  - `docs/_Archived/RNAseq_workflow/img/outs.png`
  - `docs/_Archived/RNAseq_workflow/img/multiqc.png`
- local browser preview confirmed:
  - landing page renders correctly
  - RNA-seq page renders correctly
  - images load
  - nav/sidebar work
  - code copy buttons remain present

## Notes

- This PR intentionally keeps the current archived RNA-seq pilot rather than retargeting Phase 1 to `RNAseq_general_workflow`.
- No analysis logic was changed.
- No notebooks are executed as part of site rendering.

## Manual prerequisite before merge

GitHub Pages must be set to:

`Settings -> Pages -> Build and deployment -> Source = GitHub Actions`

Without that repo setting, the deploy workflow will not complete successfully.