### PR TITLE
Implement Phase 2 Quarto site and prep catalog structure for Phase 3

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,78 @@
+name: Publish Quarto Site
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Render Quarto site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Generate site catalog artifacts
+        run: python3 scripts/build_site_catalog.py
+
+      - name: Verify generated artifacts are committed
+        run: git diff --exit-code -- _quarto.yml _generated/workflow-catalog.qmd
+
+      - name: Render site
+        run: quarto render
+
+      - name: Verify .nojekyll
+        run: test -f docs/.nojekyll
+
+      - name: Verify rendered site pages
+        run: |
+          test -f docs/index.html
+          test -f docs/rnaseq-workflow.html
+          test -f docs/CONTRIBUTING_to_site.html
+
+      - name: Verify archived RNA-seq images
+        run: |
+          test -f docs/_Archived/RNAseq_workflow/img/fastqs.png
+          test -f docs/_Archived/RNAseq_workflow/img/list.png
+          test -f docs/_Archived/RNAseq_workflow/img/outs.png
+          test -f docs/_Archived/RNAseq_workflow/img/multiqc.png
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs
+
+  deploy:
+    name: Deploy Quarto site
+    if: github.event_name == 'push'
+    needs: render
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,7 @@ dmypy.json
 
 # profiling data
 .prof
+
+/.quarto/
+**/*.quarto_ipynb
+/docs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@
 
 This guide explains how to contribute new workflows to the BMBL analysis notebooks repository.
 
+For Quarto website additions, use the dedicated checklist in [CONTRIBUTING_to_site.md](CONTRIBUTING_to_site.md).
+
 ## How to Contribute
 
 ### 1. Prepare Your Workflow

--- a/CONTRIBUTING_to_site.md
+++ b/CONTRIBUTING_to_site.md
@@ -1,0 +1,62 @@
+---
+title: "How to Add a Workflow to the Website"
+---
+
+# How to add a workflow to the website
+
+Use this checklist when you migrate a workflow into the Quarto site.
+
+## Copy-paste checklist
+
+1. Pick one workflow folder and read its `README.md`, numbered notebooks, and any `.ai_context.md` file before editing the site.
+2. Confirm the workflow has committed source materials you can display directly: prose, code blocks, and any figures already stored in the repo.
+3. Do not re-execute or re-knit notebooks. The site is display-only and relies on committed text and figures.
+4. Add or update the workflow entry in `site/catalog.yml`, including its category, label, `repo_path`, and whether it is a GitHub link or an internal Quarto page.
+5. Create or update the Quarto page if the workflow is being migrated into the site, and add the `workflow.id` plus `workflow.repo_path` front matter metadata.
+6. Reuse existing files instead of copying analysis content into a second location. Summarize the workflow briefly, then point readers to the source notebooks when needed.
+7. Reference only committed images and assets from the repository. If a figure is missing, note it in the PR instead of regenerating it.
+8. Run `python3 scripts/build_site_catalog.py`, then `quarto render`, from the repo root.
+9. Verify the page in the rendered site: links work, images load, copy-code buttons appear, and the GitHub source link points to the correct workflow folder.
+
+## Fixed page template
+
+Every workflow page should stay within this structure:
+
+```markdown
+# <Workflow name>
+
+---
+title: "<Workflow name>"
+workflow:
+  id: "<catalog id>"
+  repo_path: "<repo-relative workflow folder>"
+---
+
+## What it does
+2–3 sentences.
+
+## When to use it
+Inputs, outputs, and what question it answers.
+
+## Prerequisites
+Required packages and example data.
+
+## Steps
+Rendered code + figures from the existing .rmd (usage + short rationale per step).
+
+### <Step heading>
+Individual step details.
+
+## Gotchas / notes
+Common pitfalls, parameter choices worth knowing.
+
+---
+[ 📄 View source on GitHub ]
+```
+
+## Page-building notes
+
+- Keep the site tone at the usage-and-rationale level. This is not a from-scratch teaching course.
+- Preserve analysis logic exactly as it exists in the repo. If source content is broken or incomplete, record that in the PR instead of changing the science.
+- Prefer small, reviewable PRs grouped by workflow family or category.
+- `README.md` stays manual for now. Updating `site/catalog.yml` does not automatically update the root repository README.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **Important Note: This repository is still under development and the information contained within it may change. If you have any feedback or suggestions, feel free to open an issue or reach out to us.**
 
+Browse the tutorial site: [osu-bmbl.github.io/BMBL-analysis-notebooks](https://osu-bmbl.github.io/BMBL-analysis-notebooks/)
+
 ## Purpose
 
 This repository contains a collection of bioinformatics data analysis notebooks focused on providing examples of current best practices in single-cell analysis. The notebooks include both data and code.

--- a/_generated/workflow-catalog.qmd
+++ b/_generated/workflow-catalog.qmd
@@ -1,0 +1,74 @@
+### Single-cell RNA-seq
+
+- [General workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_general_workflow)
+- [10x Flex preprocessing](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_10x_Flex_preprocessing)
+- [Trajectory analysis](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_trajectory_Slingshot)
+- [Cell-cell communication](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_CellCellCommunication_branch)
+- [HPV branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_HPV_branch)
+- [Seurat to Scanpy](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_Seurat_to_Scanpy)
+- [Stomach branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_stomach_branch)
+- [ShinyCell portal](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_ShinyCell_portal)
+- [Large dataset analysis](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_Sketch_LargeData)
+- [Module enrichment](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_module_enrichment)
+- [iPSC branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_iPSC_branch)
+- [Immune branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_immune_branch)
+- [inferCNV](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_inferCNV)
+- [Label transfer](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_label_transfer_branch)
+
+### Single-cell ATAC-seq
+
+- [General workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_general_workflow)
+- [ArchR branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_ArchR_branch)
+- [Cicero branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_cicero_branch)
+- [cisTopic branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_cisTopic_branch)
+- [ChromVAR motif activity](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_ChromVAR_motif)
+- [Gene activity score](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_Gene_activity)
+
+### Single-cell Multi-omics
+
+- [AD branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scMultiome_AD_branch)
+
+### Single-cell TCR-seq
+
+- [TCR-seq analysis](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scTCRseq_analysis)
+
+### Spatial Transcriptomics
+
+- [General workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_general_workflow)
+- [BayesSpace branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_BayesSpace_branch)
+- [Giotto branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_giotto_branch)
+- [Spotlight branch](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_spotlight_branch)
+- [Cellular neighborhood](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Spatial_Cellular_neighborhood)
+
+### Bulk RNA-seq / ATAC-seq / ChIP-seq
+
+- [RNA-seq workflow pilot](rnaseq-workflow.qmd)
+- [RNA-seq nf-core workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/RNAseq_nfcore_workflow)
+- [ATAC-seq nf-core workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ATACseq_preprocessing)
+- [Bulk ATAC workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Bulk_ATAC_general_workflow)
+- [ChIP-seq workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_general_workflow)
+- [ChIP-seq workflow v2](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_general_workflow_v2)
+- [HOMER motif analysis](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_HOMER_motif)
+
+### Bisulfite sequencing
+
+- [Bismark aligner](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/BSseq_Bismark_Aligner)
+
+### Whole Genome Sequencing
+
+- [Low-pass karyotyping](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/WGS_Lowpass_karyotyping)
+
+### Gene Regulatory Networks
+
+- [CellOracle workflow](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/GRN_CellOracle)
+
+### Enrichment / downstream analysis
+
+- [Pathway enrichment](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Analysis_Pathway_enrichment)
+
+### Data utilities
+
+- [GEO download](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_GEO_download)
+- [GEO submission](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_GEO_submission)
+- [H5AD conversion](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_H5AD_conversion)
+- [SRA download](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_SRA_download)

--- a/_quarto.template.yml
+++ b/_quarto.template.yml
@@ -1,0 +1,36 @@
+project:
+  type: website
+  output-dir: docs
+  resources:
+    - _Archived/RNAseq_workflow/img/*.png
+  post-render:
+    - bash scripts/ensure-nojekyll.sh
+
+execute:
+  enabled: false
+
+website:
+  title: "BMBL Analysis Notebooks"
+  site-url: "https://osu-bmbl.github.io/BMBL-analysis-notebooks/"
+  repo-url: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks"
+  navbar:
+    logo: "https://cpb-us-w2.wpmucdn.com/u.osu.edu/dist/0/72768/files/2020/07/bmbl_logo1-300x124.png"
+    right:
+      - text: "Add a Workflow"
+        href: CONTRIBUTING_to_site.md
+      - icon: github
+        href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks"
+        aria-label: "BMBL Analysis Notebooks on GitHub"
+  sidebar:
+    style: docked
+    search: true
+    collapse-level: 1
+
+format:
+  html:
+    theme: cosmo
+    css: styles.css
+    toc: true
+    code-copy: true
+    code-overflow: wrap
+    smooth-scroll: true

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,150 @@
+project:
+  type: "website"
+  output-dir: "docs"
+  resources:
+    - "_Archived/RNAseq_workflow/img/*.png"
+  post-render:
+    - "bash scripts/ensure-nojekyll.sh"
+  render:
+    - "index.qmd"
+    - "CONTRIBUTING_to_site.md"
+    - "rnaseq-workflow.qmd"
+execute:
+  enabled: false
+website:
+  title: "BMBL Analysis Notebooks"
+  site-url: "https://osu-bmbl.github.io/BMBL-analysis-notebooks/"
+  repo-url: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks"
+  navbar:
+    logo: "https://cpb-us-w2.wpmucdn.com/u.osu.edu/dist/0/72768/files/2020/07/bmbl_logo1-300x124.png"
+    right:
+      - text: "RNA-seq workflow pilot"
+        href: "rnaseq-workflow.qmd"
+      - text: "Add a Workflow"
+        href: "CONTRIBUTING_to_site.md"
+      - icon: "github"
+        href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks"
+        aria-label: "BMBL Analysis Notebooks on GitHub"
+  sidebar:
+    style: "docked"
+    search: true
+    collapse-level: 1
+    contents:
+      - href: "index.qmd"
+        text: "Home"
+      - section: "Single-cell RNA-seq"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_general_workflow"
+            text: "General workflow"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_10x_Flex_preprocessing"
+            text: "10x Flex preprocessing"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_trajectory_Slingshot"
+            text: "Trajectory analysis"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_CellCellCommunication_branch"
+            text: "Cell-cell communication"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_HPV_branch"
+            text: "HPV branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_Seurat_to_Scanpy"
+            text: "Seurat to Scanpy"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_stomach_branch"
+            text: "Stomach branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_ShinyCell_portal"
+            text: "ShinyCell portal"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_Sketch_LargeData"
+            text: "Large dataset analysis"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_module_enrichment"
+            text: "Module enrichment"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_iPSC_branch"
+            text: "iPSC branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_immune_branch"
+            text: "Immune branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_inferCNV"
+            text: "inferCNV"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_label_transfer_branch"
+            text: "Label transfer"
+      - section: "Single-cell ATAC-seq"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_general_workflow"
+            text: "General workflow"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_ArchR_branch"
+            text: "ArchR branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_cicero_branch"
+            text: "Cicero branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_cisTopic_branch"
+            text: "cisTopic branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_ChromVAR_motif"
+            text: "ChromVAR motif activity"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_Gene_activity"
+            text: "Gene activity score"
+      - section: "Single-cell Multi-omics"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scMultiome_AD_branch"
+            text: "AD branch"
+      - section: "Single-cell TCR-seq"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scTCRseq_analysis"
+            text: "TCR-seq analysis"
+      - section: "Spatial Transcriptomics"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_general_workflow"
+            text: "General workflow"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_BayesSpace_branch"
+            text: "BayesSpace branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_giotto_branch"
+            text: "Giotto branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ST_spotlight_branch"
+            text: "Spotlight branch"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Spatial_Cellular_neighborhood"
+            text: "Cellular neighborhood"
+      - section: "Bulk RNA-seq / ATAC-seq / ChIP-seq"
+        contents:
+          - href: "rnaseq-workflow.qmd"
+            text: "RNA-seq workflow pilot"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/RNAseq_nfcore_workflow"
+            text: "RNA-seq nf-core workflow"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ATACseq_preprocessing"
+            text: "ATAC-seq nf-core workflow"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Bulk_ATAC_general_workflow"
+            text: "Bulk ATAC workflow"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_general_workflow"
+            text: "ChIP-seq workflow"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_general_workflow_v2"
+            text: "ChIP-seq workflow v2"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_HOMER_motif"
+            text: "HOMER motif analysis"
+      - section: "Bisulfite sequencing"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/BSseq_Bismark_Aligner"
+            text: "Bismark aligner"
+      - section: "Whole Genome Sequencing"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/WGS_Lowpass_karyotyping"
+            text: "Low-pass karyotyping"
+      - section: "Gene Regulatory Networks"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/GRN_CellOracle"
+            text: "CellOracle workflow"
+      - section: "Enrichment / downstream analysis"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Analysis_Pathway_enrichment"
+            text: "Pathway enrichment"
+      - section: "Data utilities"
+        contents:
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_GEO_download"
+            text: "GEO download"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_GEO_submission"
+            text: "GEO submission"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_H5AD_conversion"
+            text: "H5AD conversion"
+          - href: "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_SRA_download"
+            text: "SRA download"
+      - href: "CONTRIBUTING_to_site.md"
+        text: "How to Add a Workflow"
+format:
+  html:
+    theme: "cosmo"
+    css: "styles.css"
+    toc: true
+    code-copy: true
+    code-overflow: "wrap"
+    smooth-scroll: true

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,45 @@
+---
+title: "BMBL Analysis Notebooks"
+page-layout: full
+---
+
+::: {.hero-panel}
+![](https://cpb-us-w2.wpmucdn.com/u.osu.edu/dist/0/72768/files/2020/07/bmbl_logo1-300x124.png){.hero-logo}
+
+# BMBL Analysis Notebooks
+
+This site turns the repository into a browsable, static reference for bioinformatics workflows. It is designed for readers who already know the assays and analysis ecosystem and want a clearer way to review workflow usage, code, and existing figures.
+
+The repository is not an introduction to sequencing analysis, so this site focuses on workflow usage, expected inputs and outputs, committed figures, and source links rather than runnable notebooks or beginner lessons.
+
+Today the site includes one internal RNA-seq pilot page and a full catalog of the remaining workflow folders. As Phase 3 expands coverage, those GitHub links can be replaced with additional Quarto pages without changing the site structure.
+:::
+
+::: {.grid}
+::: {.g-col-12 .g-col-lg-8}
+## Purpose
+
+The repository contains practical bioinformatics notebooks and companion files for workflows used by the BMBL lab. This website keeps the materials in the same repo and presents them as a display-only reading experience rather than a runnable tutorial environment.
+
+::: {.callout-note}
+## Current coverage
+
+- The RNA-seq pilot is available as a full internal site page: [RNA-seq workflow pilot](rnaseq-workflow.qmd)
+- All other entries currently link to their source folders on GitHub while they wait for full migration
+- Contributor instructions for future site pages live in [How to Add a Workflow](CONTRIBUTING_to_site.md)
+:::
+:::
+
+::: {.g-col-12 .g-col-lg-4}
+::: {.pilot-card}
+### Featured Workflow Page
+
+[RNA-seq workflow pilot](rnaseq-workflow.qmd)
+
+Browse the current pilot page for prerequisites, step-by-step usage notes, committed images, and links back to the source files on GitHub.
+:::
+:::
+:::
+
+## Workflow catalog
+{{< include /_generated/workflow-catalog.qmd >}}

--- a/rnaseq-workflow.qmd
+++ b/rnaseq-workflow.qmd
@@ -1,0 +1,235 @@
+---
+title: "RNA-seq Workflow"
+subtitle: "Bulk RNA-seq preprocessing and downstream analysis reference"
+workflow:
+  id: rnaseq-pilot
+  repo_path: "_Archived/RNAseq_workflow"
+---
+
+## What it does
+
+This workflow provides a bulk RNA-seq reference path that starts with preprocessing on the OSC cluster and continues into downstream analysis in R. The materials cover fastq preparation, alignment and quantification submission, count-matrix preparation, PCA, differential expression, volcano plots, and enrichment analyses.
+
+## When to use it
+
+Use this workflow when you already have paired-end bulk RNA-seq data and want a lab-specific guide for moving from raw fastq files to count and metadata tables, then into downstream exploratory and differential expression analyses. It is most useful when you want example commands, expected intermediate files, and template code for common follow-up analysis decisions.
+
+## Prerequisites
+
+- Access to the workflow folder: [`_Archived/RNAseq_workflow`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow)
+- An OSC account and access to the project space described in the preprocessing tutorial
+- R plus the packages listed in [`RNAseq_install_packages.R`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_install_packages.R)
+- Example input tables from [`Example_Data`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Example_Data)
+- The main source files used by this page:
+  - [`RNAseq_Preprocessing_Tutorial.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_Preprocessing_Tutorial.md)
+  - [`RNAseq_Downstream_Analysis.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_Downstream_Analysis.md)
+  - [`downstream_analysis_template.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template.Rmd)
+  - [`downstream_analysis_template_using_limma.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template_using_limma.Rmd)
+  - [`limma_deg.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/limma_deg.Rmd)
+
+## Steps
+
+### Prepare OSC tools, references, and input data
+
+The preprocessing tutorial assumes OSC access and uses shared lab paths for tools and reference genomes. Before submitting jobs, confirm the correct species reference and prepare your fastq files in sample-level folders.
+
+```bash
+/fs/ess/PCON0022/tools
+/fs/ess/PCON0022/tools/genome/Mus_musculus.GRCm38.99
+/fs/ess/PCON0022/tools/genome/Homo_sapiens.GRCh38.99
+```
+
+If you are using the provided example data, the tutorial points to the OSC copy and the local [`Example_Data`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Example_Data) folder so you can compare expected inputs and outputs.
+
+### Organize fastq files and generate `fastq_list.txt`
+
+Each sample should be stored in its own folder, and the preprocessing scripts expect a `fastq_list.txt` with paired-end files and sample names. The provided helper script automates the list construction after you make the preprocessing scripts executable and load the expected OSC modules.
+
+```bash
+chmod +x *
+module load gnu mkl R/4.0.2
+Rscript build_fastq_list.R
+```
+
+::: {.grid}
+::: {.g-col-12 .g-col-lg-6}
+![Example fastq folder layout](_Archived/RNAseq_workflow/img/fastqs.png)
+:::
+::: {.g-col-12 .g-col-lg-6}
+![Example fastq list layout](_Archived/RNAseq_workflow/img/list.png)
+:::
+:::
+
+The relevant preprocessing files live under [`Preprocessing_code`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Preprocessing_code):
+
+- [`build_fastq_list.R`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/build_fastq_list.R)
+- [`run_primary_alignment.sh`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/run_primary_alignment.sh)
+- [`submit_primary_alignment.sh`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/submit_primary_alignment.sh)
+- [`run_quantification.sh`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/Preprocessing_code/run_quantification.sh)
+
+### Submit alignment jobs
+
+The alignment step uses `run_primary_alignment.sh` and expects you to set the working directory, reference genome, and an OSC Slurm header before submission. The tutorial gives this example header as a starting point:
+
+```bash
+#!/usr/bin/bash
+#SBATCH --account PCON0022
+#SBATCH --time=00:30:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=8
+#SBATCH --mem=32GB
+```
+
+After updating the script for your run, submit the alignment jobs from the correct working directory:
+
+```bash
+./submit_primary_alignment.sh
+```
+
+The tutorial notes that this step should produce `alignment_out`, `fastp_out`, and `result` directories, including `.bam`, `.sam`, `.sorted.bam`, and pre-alignment QC outputs.
+
+### Run quantification and create analysis tables
+
+Once alignment jobs finish, submit quantification and then convert the relevant output into `counts.csv` and `meta.csv`. The workflow suggests checking job completion first and then launching the quantification step.
+
+```bash
+squeue -u USERNAME
+sbatch run_quantification.sh
+```
+
+After quantification, the guide expects you to download `out2.txt`, convert it into `counts.csv`, and build a matching `meta.csv` whose sample names align with the count-matrix columns. The example files in [`Example_Data`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow/Example_Data) show the expected format.
+
+### Optionally generate a MultiQC report
+
+The preprocessing tutorial includes an optional MultiQC pass for summarizing QC outputs. It provides setup commands for a `multiqc` environment and a simple report-generation command from the results directory.
+
+```bash
+ml python
+conda create -n multiqc python=3.8
+source activate multiqc
+pip install multiqc
+multiqc *
+```
+
+::: {.grid}
+::: {.g-col-12 .g-col-lg-6}
+![Quantification result files](_Archived/RNAseq_workflow/img/outs.png)
+:::
+::: {.g-col-12 .g-col-lg-6}
+![Example MultiQC report view](_Archived/RNAseq_workflow/img/multiqc.png)
+:::
+:::
+
+### Load counts, metadata, and required packages for downstream analysis
+
+The downstream templates begin by installing or loading the required packages, reading `counts.csv` and `meta.csv`, removing duplicate gene rows, and filtering low-count genes. The package list in [`RNAseq_install_packages.R`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_install_packages.R) includes the core analysis stack used across the templates, including `DESeq2`, `limma`, `EnhancedVolcano`, `enrichR`, `fgsea`, and `msigdbr`.
+
+```r
+counts <- read.csv("./Example_Data/counts.csv")
+meta <- read.csv("./Example_Data/meta.csv", stringsAsFactors = FALSE)
+colnames(meta)[1] <- "sample_id"
+colnames(meta)[2] <- "group"
+keep <- rowSums(counts) >= 50
+counts <- counts[keep, ]
+```
+
+The Markdown walkthrough calls out a few user-adjustable parameters at this stage, especially the low-count filtering threshold and datatable page length for metadata inspection.
+
+### Choose a downstream analysis path and inspect PCA
+
+The repository includes both a DESeq2-based template and a limma-based template. Both workflows use the same `counts.csv` and `meta.csv` handoff, but they differ in the modeling code used for differential expression.
+
+For PCA, the downstream guide highlights that the grouping variable should be chosen intentionally based on the biological question, such as time, treatment, or the workflow's default `group` column.
+
+```r
+pcaData <- plotPCA(vsd, intgroup = c("time"), returnData = TRUE)
+```
+
+```r
+pcaData <- plotPCA(vsd, intgroup = c("treatment"), returnData = TRUE)
+```
+
+### Define differential expression comparisons
+
+The downstream workflow emphasizes that defining the comparison groups is one of the most important setup choices in the analysis. The DESeq2 template uses a contrast on the `group` variable, while the limma template builds a design matrix and contrast matrix from metadata levels.
+
+```r
+this_groups <- c("group_1", "group_2")
+```
+
+```r
+res <- results(dds, contrast = c("group", "NCH3", "NCH1"))
+write.csv(res, "./result/Group1_vs_Group2.csv")
+```
+
+```r
+stopifnot(all(meta$sample_id == colnames(counts)))
+contrast.matrix <- makeContrasts(
+  paste0(levels(group)[1], "-", levels(group)[2]),
+  levels = design
+)
+```
+
+### Review volcano plots and enrichment results
+
+For volcano plots, the tutorial shows example cutoffs for adjusted p-value and log2 fold change and notes that these should be adapted to the experiment. The downstream guide then moves into two enrichment patterns: over-representation analysis with `enrichR` and gene set enrichment analysis with `fgsea`.
+
+```r
+EnhancedVolcano(
+  res,
+  lab = rownames(res),
+  x = "log2FoldChange",
+  y = "padj",
+  pCutoff = 0.05,
+  FCcutoff = 1.5
+)
+```
+
+```r
+dbs <- c(
+  "GO_Molecular_Function_2018",
+  "GO_Cellular_Component_2018",
+  "GO_Biological_Process_2018",
+  "KEGG_2019_Human"
+)
+```
+
+If the data are from mouse, the guide notes that the KEGG database entry should be switched to `KEGG_2019_Mouse`.
+
+### Run fgsea with the appropriate database and permutation count
+
+The fgsea section uses `msigdbr` or a saved qsave object to load gene sets, then runs `fgsea` with an explicit permutation count. The source templates show both GO Biological Process and KEGG-style examples for the enrichment stage.
+
+```r
+if (!file.exists("../all_gene_sets_human.qsave")) {
+  all_gene_sets <- msigdbr(species = "human")
+  qs::qsave(all_gene_sets, "all_gene_sets_human.qsave")
+} else {
+  all_gene_sets <- qs::qread("../all_gene_sets_human.qsave")
+}
+```
+
+```r
+fgseaRes <- fgsea(pathways = m_list, stats = res_gsea, nperm = 1000)
+```
+
+The main downstream source files for full code context are:
+
+- [`RNAseq_Downstream_Analysis.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/RNAseq_Downstream_Analysis.md)
+- [`downstream_analysis_template.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template.Rmd)
+- [`downstream_analysis_template_using_limma.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/downstream_analysis_template_using_limma.Rmd)
+- [`limma_deg.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/_Archived/RNAseq_workflow/limma_deg.Rmd)
+
+## Gotchas / notes
+
+- This workflow assumes OSC-specific paths, module loads, and Slurm submission patterns, so cluster and filesystem details may need to be adapted for another environment.
+- Make sure the species reference and downstream database choice match your dataset, especially for human-versus-mouse KEGG and gene-set resources.
+- `counts.csv` and `meta.csv` need to stay aligned; sample identifiers in metadata should match the count-matrix columns before differential expression begins.
+- The low-count filter (`keep`) is intentionally adjustable and should be tuned to the dataset rather than treated as a fixed universal threshold.
+- PCA interpretation depends on the `intgroup` you choose, and the volcano plot cutoffs shown in the templates are example defaults rather than mandatory settings.
+- In the limma template, the contrast matrix is derived from metadata levels, so confirm that factor levels and group ordering reflect the comparison you actually want.
+- The number of permutations in `fgsea` is also a tuning decision; higher values can improve granularity at the cost of compute time.
+
+---
+
+[📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/_Archived/RNAseq_workflow)

--- a/scripts/build_site_catalog.py
+++ b/scripts/build_site_catalog.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG_PATH = REPO_ROOT / "site" / "catalog.yml"
+TEMPLATE_PATH = REPO_ROOT / "_quarto.template.yml"
+QUARTO_PATH = REPO_ROOT / "_quarto.yml"
+WORKFLOW_CATALOG_PATH = REPO_ROOT / "_generated" / "workflow-catalog.qmd"
+REPO_TREE_BASE = "https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/"
+STATIC_RENDER_PAGES = ["index.qmd", "CONTRIBUTING_to_site.md"]
+
+
+def parse_yaml_text(text: str, source_label: str):
+    try:
+        import yaml  # type: ignore
+
+        return yaml.safe_load(text)
+    except ModuleNotFoundError:
+        ruby = subprocess.run(
+            [
+                "ruby",
+                "-e",
+                "require 'yaml'; require 'json'; print JSON.generate(YAML.safe_load(ARGF.read))",
+            ],
+            input=text,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if ruby.returncode != 0:
+            raise SystemExit(
+                f"Unable to parse YAML for {source_label} with Python or Ruby:\n{ruby.stderr.strip()}"
+            )
+        return json.loads(ruby.stdout)
+
+
+def load_yaml(path: Path):
+    return parse_yaml_text(path.read_text(), str(path))
+
+
+def dump_scalar(value):
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(str(value))
+
+
+def dump_yaml(value, indent=0):
+    space = " " * indent
+    lines = []
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if isinstance(item, (dict, list)):
+                lines.append(f"{space}{key}:")
+                lines.append(dump_yaml(item, indent + 2))
+            else:
+                lines.append(f"{space}{key}: {dump_scalar(item)}")
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                keys = list(item.keys())
+                if not keys:
+                    lines.append(f"{space}- {{}}")
+                    continue
+                first = keys[0]
+                first_value = item[first]
+                if isinstance(first_value, (dict, list)):
+                    lines.append(f"{space}- {first}:")
+                    lines.append(dump_yaml(first_value, indent + 4))
+                else:
+                    lines.append(f"{space}- {first}: {dump_scalar(first_value)}")
+                for key in keys[1:]:
+                    child = item[key]
+                    if isinstance(child, (dict, list)):
+                        lines.append(f"{space}  {key}:")
+                        lines.append(dump_yaml(child, indent + 4))
+                    else:
+                        lines.append(f"{space}  {key}: {dump_scalar(child)}")
+            elif isinstance(item, list):
+                lines.append(f"{space}-")
+                lines.append(dump_yaml(item, indent + 2))
+            else:
+                lines.append(f"{space}- {dump_scalar(item)}")
+    else:
+        lines.append(f"{space}{dump_scalar(value)}")
+    return "\n".join(lines)
+
+
+def expect_list(name, value):
+    if not isinstance(value, list):
+        raise SystemExit(f"{name} must be a list.")
+    return value
+
+
+def front_matter_for(path: Path):
+    text = path.read_text()
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not match:
+        raise SystemExit(f"{path.name} is missing YAML front matter.")
+    return parse_yaml_text(match.group(1), f"front matter in {path.name}")
+
+
+def workflow_href(workflow):
+    if workflow["kind"] == "page":
+        return workflow["page"]
+    return f"{REPO_TREE_BASE}{workflow['repo_path']}"
+
+
+def ordered_categories(categories):
+    return sorted(categories, key=lambda item: (item["order"], item["label"]))
+
+
+def ordered_workflows(workflows):
+    return sorted(workflows, key=lambda item: (item["order"], item["label"]))
+
+
+def workflows_by_category(categories, workflows):
+    grouped = {category["id"]: [] for category in categories}
+    for workflow in workflows:
+        grouped[workflow["category"]].append(workflow)
+    for items in grouped.values():
+        items.sort(key=lambda item: (item["order"], item["label"]))
+    return grouped
+
+
+def validate_catalog(catalog):
+    categories = expect_list("categories", catalog.get("categories"))
+    workflows = expect_list("workflows", catalog.get("workflows"))
+
+    category_ids = set()
+    for category in categories:
+        cid = category["id"]
+        if cid in category_ids:
+            raise SystemExit(f"Duplicate category id: {cid}")
+        category_ids.add(cid)
+
+    workflow_ids = set()
+    featured = []
+    navbar = []
+    for workflow in workflows:
+        wid = workflow["id"]
+        if wid in workflow_ids:
+            raise SystemExit(f"Duplicate workflow id: {wid}")
+        workflow_ids.add(wid)
+
+        if workflow["category"] not in category_ids:
+            raise SystemExit(
+                f"Workflow {wid} uses unknown category: {workflow['category']}"
+            )
+        if workflow["kind"] not in {"page", "github"}:
+            raise SystemExit(f"Workflow {wid} has invalid kind: {workflow['kind']}")
+
+        repo_target = REPO_ROOT / workflow["repo_path"]
+        if not repo_target.exists():
+            raise SystemExit(
+                f"Workflow {wid} points to missing repo_path: {workflow['repo_path']}"
+            )
+
+        if workflow["kind"] == "page":
+            page = workflow.get("page")
+            if not page:
+                raise SystemExit(f"Workflow {wid} is missing page.")
+            page_path = REPO_ROOT / page
+            if not page_path.exists():
+                raise SystemExit(f"Workflow {wid} points to missing page file: {page}")
+
+            front_matter = front_matter_for(page_path)
+            workflow_meta = front_matter.get("workflow")
+            if not isinstance(workflow_meta, dict):
+                raise SystemExit(f"{page} is missing workflow metadata.")
+            if workflow_meta.get("id") != wid:
+                raise SystemExit(
+                    f"{page} workflow.id mismatch: expected {wid}, found {workflow_meta.get('id')}"
+                )
+            if workflow_meta.get("repo_path") != workflow["repo_path"]:
+                raise SystemExit(
+                    f"{page} workflow.repo_path mismatch: expected {workflow['repo_path']}, "
+                    f"found {workflow_meta.get('repo_path')}"
+                )
+
+        if workflow.get("featured"):
+            featured.append(wid)
+        if workflow.get("navbar"):
+            navbar.append(wid)
+
+    if len(featured) > 1:
+        raise SystemExit(f"Only one workflow can be featured. Found: {', '.join(featured)}")
+    if len(navbar) > 1:
+        raise SystemExit(f"Only one workflow can appear in the navbar workflow slot. Found: {', '.join(navbar)}")
+
+    for wid in navbar:
+        workflow = next(item for item in workflows if item["id"] == wid)
+        if workflow["kind"] != "page":
+            raise SystemExit(f"Navbar workflow {wid} must be an internal page.")
+
+    return categories, workflows
+
+
+def build_quarto(template, categories, workflows):
+    grouped = workflows_by_category(categories, workflows)
+    featured_nav = next((workflow for workflow in workflows if workflow.get("navbar")), None)
+
+    project = dict(template["project"])
+    project["render"] = STATIC_RENDER_PAGES + [
+        workflow["page"]
+        for workflow in ordered_workflows(workflows)
+        if workflow["kind"] == "page"
+    ]
+
+    website = dict(template["website"])
+    navbar = dict(website["navbar"])
+    navbar_right = []
+    if featured_nav:
+        navbar_right.append({"text": featured_nav["label"], "href": featured_nav["page"]})
+    navbar_right.extend(navbar["right"])
+    navbar["right"] = navbar_right
+
+    sidebar = dict(website["sidebar"])
+    sidebar_contents = [{"href": "index.qmd", "text": "Home"}]
+    for category in ordered_categories(categories):
+        contents = [
+            {"href": workflow_href(workflow), "text": workflow["label"]}
+            for workflow in grouped[category["id"]]
+        ]
+        sidebar_contents.append({"section": category["label"], "contents": contents})
+    sidebar_contents.append(
+        {"href": "CONTRIBUTING_to_site.md", "text": "How to Add a Workflow"}
+    )
+    sidebar["contents"] = sidebar_contents
+
+    website["navbar"] = navbar
+    website["sidebar"] = sidebar
+
+    return {
+        "project": project,
+        "execute": template["execute"],
+        "website": website,
+        "format": template["format"],
+    }
+
+
+def build_workflow_catalog_qmd(categories, workflows):
+    grouped = workflows_by_category(categories, workflows)
+    lines = []
+    for category in ordered_categories(categories):
+        lines.append(f"### {category['label']}")
+        lines.append("")
+        for workflow in grouped[category["id"]]:
+            lines.append(f"- [{workflow['label']}]({workflow_href(workflow)})")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    catalog = load_yaml(CATALOG_PATH)
+    template = load_yaml(TEMPLATE_PATH)
+    categories, workflows = validate_catalog(catalog)
+
+    QUARTO_PATH.write_text(dump_yaml(build_quarto(template, categories, workflows)) + "\n")
+    WORKFLOW_CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    WORKFLOW_CATALOG_PATH.write_text(build_workflow_catalog_qmd(categories, workflows))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ensure-nojekyll.sh
+++ b/scripts/ensure-nojekyll.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p docs
+touch docs/.nojekyll

--- a/site/catalog.yml
+++ b/site/catalog.yml
@@ -1,0 +1,301 @@
+categories:
+  - id: scrna
+    label: "Single-cell RNA-seq"
+    order: 10
+  - id: scatac
+    label: "Single-cell ATAC-seq"
+    order: 20
+  - id: multiome
+    label: "Single-cell Multi-omics"
+    order: 30
+  - id: tcr
+    label: "Single-cell TCR-seq"
+    order: 40
+  - id: spatial
+    label: "Spatial Transcriptomics"
+    order: 50
+  - id: bulk
+    label: "Bulk RNA-seq / ATAC-seq / ChIP-seq"
+    order: 60
+  - id: bsseq
+    label: "Bisulfite sequencing"
+    order: 70
+  - id: wgs
+    label: "Whole Genome Sequencing"
+    order: 80
+  - id: grn
+    label: "Gene Regulatory Networks"
+    order: 90
+  - id: enrichment
+    label: "Enrichment / downstream analysis"
+    order: 100
+  - id: data
+    label: "Data utilities"
+    order: 110
+
+workflows:
+  - id: scrna-general
+    label: "General workflow"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_general_workflow"
+    order: 10
+  - id: scrna-10x-flex
+    label: "10x Flex preprocessing"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_10x_Flex_preprocessing"
+    order: 20
+  - id: scrna-trajectory
+    label: "Trajectory analysis"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_trajectory_Slingshot"
+    order: 30
+  - id: scrna-cellchat
+    label: "Cell-cell communication"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_CellCellCommunication_branch"
+    order: 40
+  - id: scrna-hpv
+    label: "HPV branch"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_HPV_branch"
+    order: 50
+  - id: scrna-seurat-scanpy
+    label: "Seurat to Scanpy"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_Seurat_to_Scanpy"
+    order: 60
+  - id: scrna-stomach
+    label: "Stomach branch"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_stomach_branch"
+    order: 70
+  - id: scrna-shinycell
+    label: "ShinyCell portal"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_ShinyCell_portal"
+    order: 80
+  - id: scrna-large
+    label: "Large dataset analysis"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_Sketch_LargeData"
+    order: 90
+  - id: scrna-module
+    label: "Module enrichment"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_module_enrichment"
+    order: 100
+  - id: scrna-ipsc
+    label: "iPSC branch"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_iPSC_branch"
+    order: 110
+  - id: scrna-immune
+    label: "Immune branch"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_immune_branch"
+    order: 120
+  - id: scrna-infercnv
+    label: "inferCNV"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_inferCNV"
+    order: 130
+  - id: scrna-label-transfer
+    label: "Label transfer"
+    category: scrna
+    kind: github
+    repo_path: "scRNAseq_label_transfer_branch"
+    order: 140
+
+  - id: scatac-general
+    label: "General workflow"
+    category: scatac
+    kind: github
+    repo_path: "scATACseq_general_workflow"
+    order: 10
+  - id: scatac-archr
+    label: "ArchR branch"
+    category: scatac
+    kind: github
+    repo_path: "scATACseq_ArchR_branch"
+    order: 20
+  - id: scatac-cicero
+    label: "Cicero branch"
+    category: scatac
+    kind: github
+    repo_path: "scATACseq_cicero_branch"
+    order: 30
+  - id: scatac-cistopic
+    label: "cisTopic branch"
+    category: scatac
+    kind: github
+    repo_path: "scATACseq_cisTopic_branch"
+    order: 40
+  - id: scatac-chromvar
+    label: "ChromVAR motif activity"
+    category: scatac
+    kind: github
+    repo_path: "scATACseq_ChromVAR_motif"
+    order: 50
+  - id: scatac-gene-activity
+    label: "Gene activity score"
+    category: scatac
+    kind: github
+    repo_path: "scATACseq_Gene_activity"
+    order: 60
+
+  - id: multiome-ad
+    label: "AD branch"
+    category: multiome
+    kind: github
+    repo_path: "scMultiome_AD_branch"
+    order: 10
+
+  - id: tcr-analysis
+    label: "TCR-seq analysis"
+    category: tcr
+    kind: github
+    repo_path: "scTCRseq_analysis"
+    order: 10
+
+  - id: spatial-general
+    label: "General workflow"
+    category: spatial
+    kind: github
+    repo_path: "ST_general_workflow"
+    order: 10
+  - id: spatial-bayesspace
+    label: "BayesSpace branch"
+    category: spatial
+    kind: github
+    repo_path: "ST_BayesSpace_branch"
+    order: 20
+  - id: spatial-giotto
+    label: "Giotto branch"
+    category: spatial
+    kind: github
+    repo_path: "ST_giotto_branch"
+    order: 30
+  - id: spatial-spotlight
+    label: "Spotlight branch"
+    category: spatial
+    kind: github
+    repo_path: "ST_spotlight_branch"
+    order: 40
+  - id: spatial-neighborhood
+    label: "Cellular neighborhood"
+    category: spatial
+    kind: github
+    repo_path: "Spatial_Cellular_neighborhood"
+    order: 50
+
+  - id: rnaseq-pilot
+    label: "RNA-seq workflow pilot"
+    category: bulk
+    kind: page
+    repo_path: "_Archived/RNAseq_workflow"
+    page: "rnaseq-workflow.qmd"
+    order: 10
+    featured: true
+    navbar: true
+  - id: bulk-rnaseq-nfcore
+    label: "RNA-seq nf-core workflow"
+    category: bulk
+    kind: github
+    repo_path: "RNAseq_nfcore_workflow"
+    order: 20
+  - id: bulk-atac-nfcore
+    label: "ATAC-seq nf-core workflow"
+    category: bulk
+    kind: github
+    repo_path: "ATACseq_preprocessing"
+    order: 30
+  - id: bulk-atac-general
+    label: "Bulk ATAC workflow"
+    category: bulk
+    kind: github
+    repo_path: "Bulk_ATAC_general_workflow"
+    order: 40
+  - id: bulk-chipseq
+    label: "ChIP-seq workflow"
+    category: bulk
+    kind: github
+    repo_path: "ChipSeq_general_workflow"
+    order: 50
+  - id: bulk-chipseq-v2
+    label: "ChIP-seq workflow v2"
+    category: bulk
+    kind: github
+    repo_path: "ChipSeq_general_workflow_v2"
+    order: 60
+  - id: bulk-homer
+    label: "HOMER motif analysis"
+    category: bulk
+    kind: github
+    repo_path: "ChipSeq_HOMER_motif"
+    order: 70
+
+  - id: bsseq-bismark
+    label: "Bismark aligner"
+    category: bsseq
+    kind: github
+    repo_path: "BSseq_Bismark_Aligner"
+    order: 10
+
+  - id: wgs-karyotyping
+    label: "Low-pass karyotyping"
+    category: wgs
+    kind: github
+    repo_path: "WGS_Lowpass_karyotyping"
+    order: 10
+
+  - id: grn-celloracle
+    label: "CellOracle workflow"
+    category: grn
+    kind: github
+    repo_path: "GRN_CellOracle"
+    order: 10
+
+  - id: enrichment-pathway
+    label: "Pathway enrichment"
+    category: enrichment
+    kind: github
+    repo_path: "Analysis_Pathway_enrichment"
+    order: 10
+
+  - id: data-geo-download
+    label: "GEO download"
+    category: data
+    kind: github
+    repo_path: "Data_GEO_download"
+    order: 10
+  - id: data-geo-submission
+    label: "GEO submission"
+    category: data
+    kind: github
+    repo_path: "Data_GEO_submission"
+    order: 20
+  - id: data-h5ad
+    label: "H5AD conversion"
+    category: data
+    kind: github
+    repo_path: "Data_H5AD_conversion"
+    order: 30
+  - id: data-sra
+    label: "SRA download"
+    category: data
+    kind: github
+    repo_path: "Data_SRA_download"
+    order: 40

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,170 @@
+@import url("https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600;8..60,700&display=swap");
+
+:root {
+  --osu-scarlet: #ba0c2f;
+  --osu-scarlet-dark: #70071c;
+  --osu-scarlet-deep: #4a0513;
+  --osu-gray: #a7b1b7;
+  --osu-gray-light-40: #cfd4d8;
+  --osu-gray-light-60: #dfe3e5;
+  --osu-gray-light-80: #eff1f2;
+  --osu-gray-light-90: #f6f7f8;
+  --osu-gray-dark-20: #868e92;
+  --osu-gray-dark-40: #646a6e;
+  --osu-gray-dark-60: #3f4443;
+  --osu-gray-dark-80: #212325;
+  --osu-white: #ffffff;
+  --site-border: rgba(63, 68, 67, 0.12);
+  --site-shadow: rgba(33, 35, 37, 0.08);
+}
+
+body {
+  background:
+    linear-gradient(180deg, var(--osu-white) 0%, var(--osu-gray-light-90) 100%);
+  color: var(--osu-gray-dark-80);
+  font-family: "Atkinson Hyperlegible", "Trebuchet MS", sans-serif;
+}
+
+.navbar {
+  background: rgba(255, 255, 255, 0.96);
+  border-bottom: 1px solid var(--site-border);
+  backdrop-filter: blur(10px);
+}
+
+.navbar-brand,
+.nav-link,
+.sidebar-title,
+.sidebar-item-text,
+.quarto-title-meta-heading,
+.menu-text {
+  font-family: "Atkinson Hyperlegible", "Trebuchet MS", sans-serif;
+}
+
+.hero-panel {
+  padding: 2.5rem;
+  margin: 1.2rem 0 2rem;
+  border: 1px solid var(--site-border);
+  border-radius: 1.6rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(246, 247, 248, 0.98));
+  box-shadow: 0 20px 50px var(--site-shadow);
+}
+
+.hero-panel h1,
+.pilot-card h3,
+h1,
+h2,
+h3 {
+  font-family: "Atkinson Hyperlegible", "Avenir Next", sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.hero-logo {
+  max-width: 210px;
+  margin-bottom: 1.2rem;
+}
+
+.pilot-card {
+  height: 100%;
+  padding: 1.4rem;
+  border: 1px solid var(--site-border);
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(180deg, var(--osu-white), var(--osu-gray-light-90));
+  box-shadow: 0 16px 36px rgba(33, 35, 37, 0.06);
+}
+
+.pilot-card a,
+a {
+  color: var(--osu-scarlet);
+}
+
+.callout.callout-note {
+  border-radius: 1rem;
+}
+
+.callout.callout-note h2 {
+  font-size: 1.1rem;
+}
+
+a[href^="https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/"]::after {
+  content: " ↗";
+  font-size: 0.9em;
+}
+
+a:hover,
+a:focus,
+.nav-link:hover,
+.nav-link:focus,
+.sidebar-link:hover,
+.sidebar-link:focus {
+  color: var(--osu-scarlet-dark);
+}
+
+.sidebar {
+  background: rgba(246, 247, 248, 0.88);
+  border-right: 1px solid var(--site-border);
+}
+
+.sidebar .active,
+.sidebar .sidebar-link.active,
+.sidebar nav[role="doc-toc"] a.active,
+.nav-link.active,
+.menu-text:hover {
+  color: var(--osu-scarlet);
+}
+
+.quarto-title-block .quarto-title-banner {
+  background:
+    linear-gradient(135deg, rgba(246, 247, 248, 0.98), rgba(223, 227, 229, 0.95));
+  color: var(--osu-gray-dark-80);
+}
+
+.quarto-title-block .subtitle {
+  color: var(--osu-gray-dark-40);
+}
+
+.code-copy-button {
+  border-radius: 999px;
+  color: var(--osu-scarlet);
+}
+
+img {
+  border-radius: 1rem;
+  box-shadow: 0 12px 32px rgba(33, 35, 37, 0.08);
+}
+
+pre,
+.sourceCode {
+  border: 1px solid rgba(167, 177, 183, 0.28);
+  border-radius: 1rem;
+}
+
+.quarto-grid-item,
+.quarto-title-meta,
+.table,
+.callout {
+  border-color: var(--site-border);
+}
+
+.navbar .nav-link,
+.sidebar .sidebar-item-text,
+.toc-actions,
+#TOC a {
+  color: var(--osu-gray-dark-60);
+}
+
+.sidebar-section .sidebar-item-container .sidebar-item-text {
+  font-weight: 700;
+}
+
+#TOC a:hover,
+#TOC a.active {
+  color: var(--osu-scarlet);
+}
+
+@media (max-width: 991px) {
+  .hero-panel {
+    padding: 1.6rem;
+  }
+}


### PR DESCRIPTION
## Summary
- implement the Phase 2 Quarto tutorial/reference site foundation
- add the real landing page, RNA-seq pilot page, category-based navigation, and contributor guide
- centralize site workflow data into a catalog so the site structure is easier to maintain before Phase 3 fan-out

## Phase 2 deliverables included
- add Quarto site configuration and shared styling
- add the real homepage workflow catalog
- keep the RNA-seq pilot as the only internal workflow page
- add `CONTRIBUTING_to_site.md`
- update navigation to use workflow categories
- add the Pages publishing workflow and `.nojekyll` handling
- add the live site link in `README.md`

## Follow-on organizational improvements included in the same PR
- add `site/catalog.yml` as the canonical Quarto workflow catalog
- generate `_quarto.yml` and `_generated/workflow-catalog.qmd` from the catalog
- add lightweight validation for internal workflow pages
- update contributor instructions and CI for the catalog-driven flow

## Validation
- `python3 scripts/build_site_catalog.py`
- `quarto render`

## Notes
- the site remains display-only and does not execute notebooks
- the RNA-seq pilot remains the only internal workflow page
- README workflow taxonomy stays manual for now