### PR TITLE
Refine internal workflow pages for clarity and consistency

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -12,7 +12,7 @@ This site turns the repository into a browsable, static reference for bioinforma
 
 The repository is not an introduction to sequencing analysis, so this site focuses on workflow usage, expected inputs and outputs, committed figures, and source links rather than runnable notebooks or beginner lessons.
 
-Today the site includes one internal RNA-seq pilot page and a full catalog of the remaining workflow folders. As Phase 3 expands coverage, those GitHub links can be replaced with additional Quarto pages without changing the site structure.
+The workflow catalog below is now internalized into the site: each entry is presented as a Quarto page built from committed repository materials without re-executing the notebooks.
 :::
 
 ::: {.grid}
@@ -22,21 +22,22 @@ Today the site includes one internal RNA-seq pilot page and a full catalog of th
 The repository contains practical bioinformatics notebooks and companion files for workflows used by the BMBL lab. This website keeps the materials in the same repo and presents them as a display-only reading experience rather than a runnable tutorial environment.
 
 ::: {.callout-note}
-## Current coverage
+## How to use this site
 
-- The RNA-seq pilot is available as a full internal site page: [RNA-seq workflow pilot](rnaseq-workflow.qmd)
-- All other entries currently link to their source folders on GitHub while they wait for full migration
-- Contributor instructions for future site pages live in [How to Add a Workflow](CONTRIBUTING_to_site.md)
+- Browse workflows by assay category using the catalog and left-hand navigation
+- Use each workflow page as a Tier B usage-and-rationale reference, not as a from-scratch training course
+- Follow the GitHub source links on each page when you need the original workflow folder, notebooks, or companion files
+- Contributor instructions for maintaining the site live in [How to Add a Workflow](CONTRIBUTING_to_site.md)
 :::
 :::
 
 ::: {.g-col-12 .g-col-lg-4}
 ::: {.pilot-card}
-### Featured Workflow Page
+### Suggested Starting Page
 
-[RNA-seq workflow pilot](rnaseq-workflow.qmd)
+[RNA-seq Workflow](rnaseq-workflow.qmd)
 
-Browse the current pilot page for prerequisites, step-by-step usage notes, committed images, and links back to the source files on GitHub.
+Start here for a fuller example of the in-site workflow-page format, including prerequisites, structured steps, committed images, and links back to the source materials.
 :::
 :::
 :::

--- a/site/workflows/bulk-atac-nfcore.qmd
+++ b/site/workflows/bulk-atac-nfcore.qmd
@@ -28,7 +28,7 @@ Use this workflow when you want a reproducible, containerized ATAC-seq pipeline 
 
 ## Steps
 
-### Build the samplesheet and run wrapper script
+### Build the samplesheet and define the run wrapper
 
 The README expects a project directory with a samplesheet plus a small `run_atac.sh` wrapper that sets `NXF_HOME`, loads Java, and launches `nf-core/atacseq`.
 
@@ -59,7 +59,9 @@ nextflow run nf-core/atacseq \
     -resume
 ```
 
-### Use the built-in nf-core output structure for QC and peak review
+The samplesheet plus wrapper-script combination is the main operational pattern in this folder: project-specific inputs live in the sheet, while resource and runtime settings live in the launch script.
+
+### Use the built-in nf-core outputs for QC, peaks, and accessibility review
 
 The README organizes the outputs conceptually into alignment results, peak calling, QC reports, differential analysis, and visualization assets rather than giving a custom downstream notebook.
 
@@ -69,7 +71,9 @@ The main checkpoints are:
 - MultiQC and alignment metrics
 - consensus peaks and differential accessibility results
 
-### Tune optional parameters only where the experiment requires it
+That means the first review step after a run is not a custom result script; it is reading the nf-core output tree and identifying which directories matter for your downstream question.
+
+### Tune optional pipeline flags only where the experiment requires it
 
 The committed guide lists the most important flags for customizing the pipeline, including aligner choice, peak mode, and skip flags.
 
@@ -89,12 +93,17 @@ The committed guide lists the most important flags for customizing the pipeline,
 
 This page stays concise because the repo source is concise, but the main practical message is that read length, genome, and aligner choice are part of the run contract and should be set deliberately.
 
+### Start with test mode when validating a new environment
+
+One practical note worth preserving from the README is the recommendation to begin with `-profile test` when you are validating the environment or the basic pipeline setup. That is especially useful for distinguishing configuration problems from full-scale dataset runtime issues.
+
 ## Gotchas / notes
 
 - This folder is README-driven and does not include a committed notebook or figures.
 - The README title has a small typo (`atacseqx`), but the actual commands and linked docs clearly target `nf-core/atacseq`.
 - The guide recommends testing first with `-profile test`, which is worth preserving for users validating their environment.
 - Resource settings in the example script are substantial; readers should adapt them to their dataset size and scheduler limits.
+- The example wrapper assumes paired-end data and a specific Java/module environment, so readers should adapt both compute settings and runtime modules to their own system.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ATACseq_preprocessing)

--- a/site/workflows/bulk-chipseq-v2.qmd
+++ b/site/workflows/bulk-chipseq-v2.qmd
@@ -31,7 +31,7 @@ Use this workflow when you want a transparent, shell-oriented ChIP-seq preproces
 
 ## Steps
 
-### Inspect reads and trim adapters
+### Run initial FastQC, then trim adapters and recheck read quality
 
 The workflow starts with `FastQC` on paired reads, then reruns QC after trimming adapters with `TrimGalore`.
 
@@ -50,7 +50,9 @@ mkdir ${basename}.trim.fastQC
   --fastqc_args "-f fastq -o ${basename}.trim.fastQC -t $core"
 ```
 
-### Align with Bowtie2 and keep properly paired reads
+The key idea in this opening stage is not just “trim reads,” but “compare QC before and after trimming” so adapter removal can be verified before alignment.
+
+### Align with Bowtie2 and restrict the data to properly paired reads
 
 After trimming, the guide aligns with Bowtie2 in `--very-sensitive` mode, sorts/indexes the BAM, and then restricts downstream processing to properly paired reads.
 
@@ -68,7 +70,7 @@ samtools sort -@ $core -o ${basename}.s.filt.bam ${basename}.filt.bam
 samtools index -@ $core ${basename}.s.filt.bam
 ```
 
-### Remove duplicates and summarize final alignment state
+### Remove duplicates and capture alignment summaries before and after filtering
 
 The next stage uses Picard to remove duplicates, then captures alignment summaries with `samtools flagstat` before producing coverage tracks.
 
@@ -85,7 +87,9 @@ samtools flagstat -@ $core ${basename}.s.bam > ${basename}_INI_mapped_count.txt
 samtools flagstat -@ $core ${basename}.s.rms.filt.bam > ${basename}_FIN_mapped_count.txt
 ```
 
-### Generate BigWig files for downstream visualization
+Those paired flagstat outputs are the main checkpoint for understanding how much data survived the filtering and duplicate-removal stages.
+
+### Generate BigWig files for downstream visualization or peak review
 
 The README ends with `bamCoverage` from deepTools to create normalized BigWig tracks for IGV or browser-style inspection.
 
@@ -95,12 +99,17 @@ bamCoverage -b ${basename}.s.rms.filt.bam -o ${basename}.bw --normalizeUsing RPK
 
 This branch is lighter than the nf-core ChIP-seq page because it focuses on preprocessing and visualization-ready files, not on consensus peaks or motif analysis.
 
+### Use MultiQC only after all samples finish the preprocessing chain
+
+The README notes that `multiqc` becomes useful once multiple samples have completed the pipeline, so that alignment and processing statistics can be summarized across the whole batch rather than one sample at a time.
+
 ## Gotchas / notes
 
 - The committed guide is optimized for paired-end data; single-end use would need small changes.
 - Peak calling itself is not the focus of this v2 page; the workflow is mainly about clean alignment, filtering, and coverage generation.
 - The README assumes local variables like `$bt2ref_mm10` and `$basename` are already defined by the user.
 - Like several bulk branches, this folder is README-only and does not include committed figures or rendered notebook outputs.
+- The guide assumes the required modules, conda environment, and reference variables are already prepared before the commands shown here are run.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_general_workflow_v2)

--- a/site/workflows/bulk-chipseq.qmd
+++ b/site/workflows/bulk-chipseq.qmd
@@ -8,11 +8,11 @@ workflow:
 
 ## What it does
 
-This workflow uses `nf-core/chipseq` for bulk ChIP-seq processing and then points to motif discovery and motif comparison steps outside the main Nextflow run. The committed README describes the samplesheet format, major pipeline stages, OSC execution, and how the resulting peak files can be taken into STREME and Tomtom.
+This workflow uses `nf-core/chipseq` for bulk ChIP-seq processing and then points to motif discovery and motif comparison steps outside the main Nextflow run. The committed README describes the samplesheet format, major pipeline stages, OSC execution, and how the resulting peak files can be taken into STREME and Tomtom for motif interpretation.
 
 ## When to use it
 
-Use this workflow when you want a standard ChIP-seq preprocessing path that covers QC through peak calling and consensus peak analysis, followed by motif-centric interpretation of the resulting regions. It is most useful for bulk ChIP-seq projects with IP and matched input controls.
+Use this workflow when you want a standard ChIP-seq preprocessing path that covers QC through peak calling and consensus peak analysis, followed by motif-centric interpretation of the resulting regions. It is most useful for bulk ChIP-seq projects with IP and matched input controls and for readers who want the nf-core handoff summarized without reading the whole pipeline documentation.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ Use this workflow when you want a standard ChIP-seq preprocessing path that cove
 
 ## Steps
 
-### Build the ChIP-seq samplesheet
+### Build the ChIP-seq samplesheet with IP and matched controls
 
 The README expects a samplesheet that pairs each IP library with its corresponding input/control sample.
 
@@ -39,7 +39,9 @@ WT_BCATENIN_IP,BLA203A25_S16_L002_R1_001.fastq.gz,,2,BCATENIN,WT_INPUT,2
 WT_INPUT,BLA203A6_S32_L006_R1_001.fastq.gz,,1,,,
 ```
 
-### Run nf-core/chipseq through QC, alignment, and peak calling
+This samplesheet is the main workflow-specific setup contract because the downstream peak calling and comparison logic depends on the control relationships being defined correctly.
+
+### Run `nf-core/chipseq` through QC, alignment, filtering, and peak calling
 
 The main pipeline stage uses `nf-core/chipseq` with one of several aligners, then performs duplicate marking, filtering, bigWig creation, peak calling, annotation, consensus peak generation, and MultiQC summarization.
 
@@ -56,7 +58,16 @@ The main pipeline stage uses `nf-core/chipseq` with one of several aligners, the
 
 The committed README’s most important practical detail is that this is not just alignment plus MACS3: it’s a full pipeline that also builds bigWigs, consensus peaks, PCA/clustering summaries, and IGV session files.
 
-### Use peak outputs for motif discovery and motif comparison
+### Review the main peak and annotation outputs before motif analysis
+
+The README highlights two especially important deliverables from the pipeline run:
+
+- peak calling BED files such as `.narrowPeak`
+- HOMER-style peak annotation output such as `annotatePeaks.txt`
+
+Those files are the handoff into downstream motif work.
+
+### Use the peak outputs for motif discovery and motif comparison
 
 After the Nextflow run, the guide points users to motif discovery with STREME and motif comparison with Tomtom, using the called peak BED files as the main handoff.
 
@@ -72,6 +83,7 @@ The documented downstream sequence is:
 - The motif steps are described as external follow-up steps, not as fully scripted local commands in the repo.
 - The example command uses `--skip_qc`, even though the pipeline overview includes QC reporting; users should decide whether skipping QC is appropriate for their run.
 - The README mixes pipeline structure and downstream motif interpretation, so this page intentionally stays at the usage-and-rationale level instead of expanding beyond the committed source.
+- The README lists several possible aligners, but the committed example command shows one specific nf-core invocation rather than a full decision guide for choosing among them.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_general_workflow)

--- a/site/workflows/bulk-homer.qmd
+++ b/site/workflows/bulk-homer.qmd
@@ -12,7 +12,7 @@ This workflow documents a HOMER2-based path for peak annotation, motif enrichmen
 
 ## When to use it
 
-Use this workflow after you already have peak or region files from ChIP-seq, ATAC-seq, or a related bulk NGS analysis and want to interpret them in terms of nearby genes and enriched TF motifs. It is a downstream motif-analysis utility rather than a primary alignment or peak-calling pipeline.
+Use this workflow after you already have peak or region files from ChIP-seq, ATAC-seq, or a related bulk NGS analysis and want to interpret them in terms of nearby genes and enriched TF motifs. It is a downstream motif-analysis utility rather than a primary alignment or peak-calling pipeline, and it is most useful when you want a shell-oriented alternative to web-only motif tools.
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ Use this workflow after you already have peak or region files from ChIP-seq, ATA
 
 ## Steps
 
-### Install HOMER in OSC scratch space and configure the genome
+### Install HOMER in OSC scratch space and configure a genome
 
 The README is explicit that HOMER should be installed in `/scratch/` rather than `/ess/`, then added to `PATH` for later use.
 
@@ -42,7 +42,7 @@ PATH=$PATH:[path/to/HOMER]/bin/
 
 This setup detail is the most workflow-specific operational note in the committed guide.
 
-### Annotate peaks relative to nearby genes and features
+### Annotate peaks relative to genes, TSSs, and other features
 
 The first analytical step uses `annotatePeaks.pl` on BED-like regions, typically in BED-6 format, to assign nearby genes, distances to TSSs, and basic locus annotations.
 
@@ -52,7 +52,7 @@ annotatePeaks.pl [BED-like file] [name of genome you previously installed] [outp
 
 The README also notes that `-gtf`, `-m`, and `-p` can be used for alternate annotations, motif overlays, or nearest-peak references.
 
-### Run motif enrichment with HOMER
+### Run motif enrichment on the target regions
 
 For motif discovery, the guide uses `findMotifsGenome.pl`, which generates both de novo and known-motif enrichments and can optionally compare against a user-supplied background.
 
@@ -66,7 +66,9 @@ The committed README highlights the main result files:
 - `knownResults.txt`
 - motif result directories and motif summary files
 
-### Summarize motif positioning around target intervals
+In practice, this is the handoff point for most users: inspect `knownResults.html` and related output files before deciding whether a more specific positioning analysis is needed.
+
+### Summarize motif positioning around target intervals or TSSs
 
 The final branch uses `createHomer2EnrichmentTable.pl` to map motif enrichment or depletion across windows around a reference position such as the TSS.
 
@@ -85,12 +87,15 @@ The README calls out two especially useful outputs:
 - `summary.windowN.logq.txt` for positional enrichment/depletion profiles
 - `summary.bestIntervals.txt` for the strongest enriched or depleted motif intervals
 
+This last step is narrower than the motif-enrichment branch above: it is for understanding where motifs tend to occur relative to a reference point, not simply whether they are enriched at all.
+
 ## Gotchas / notes
 
 - This folder is README-only and intentionally operational; there are no committed figures or example output files in the repo.
 - HOMER setup is location-sensitive on OSC, and the README strongly prefers `/scratch/` over `/ess/`.
 - The commands use placeholders for files, genomes, and directories, so users must adapt them carefully.
 - The workflow assumes the user already has peak/region files from an upstream analysis; it does not generate peaks itself.
+- The README mixes installation, annotation, enrichment, and motif-positioning guidance in one document, so this page deliberately keeps the sequence explicit and task-oriented.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/ChipSeq_HOMER_motif)

--- a/site/workflows/bulk-rnaseq-nfcore.qmd
+++ b/site/workflows/bulk-rnaseq-nfcore.qmd
@@ -12,7 +12,7 @@ This workflow uses `nf-core/rnaseq` to process bulk RNA-seq FASTQ files into ali
 
 ## When to use it
 
-Use this workflow when you want a standardized, container-friendly bulk RNA-seq pipeline rather than a hand-assembled alignment and quantification script. It is most useful when the main goal is to generate reproducible count matrices and QC outputs that can feed directly into downstream DEG workflows.
+Use this workflow when you want a standardized, container-friendly bulk RNA-seq pipeline rather than a hand-assembled alignment and quantification script. It is most useful when the main goal is to generate reproducible count matrices and QC outputs that can feed directly into downstream DEG workflows or the RNA-seq workflow page in this site.
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ Use this workflow when you want a standardized, container-friendly bulk RNA-seq 
 
 ## Steps
 
-### Prepare the input samplesheet
+### Build the samplesheet with sample names, read files, and strandedness
 
 The README expects an `nf-core/rnaseq` samplesheet with one row per library and explicit strandedness information.
 
@@ -40,7 +40,7 @@ TREATMENT_REP1,AEG588A4_S4_L003_R1_001.fastq.gz,,reverse
 
 This is the most important workflow-specific contract: the pipeline behavior depends on the samplesheet being formatted correctly before any compute job is launched.
 
-### Run nf-core/rnaseq on the cluster or from an interactive shell
+### Launch `nf-core/rnaseq` either interactively or through Slurm
 
 The committed guide uses `Nextflow` directly and shows both a simple command and a SLURM job script for OSC-style execution.
 
@@ -68,7 +68,9 @@ nextflow run nf-core/rnaseq \
    -profile singularity
 ```
 
-### Review the main outputs for downstream analysis
+The practical choice here is not between different workflow branches but between execution contexts: a direct shell launch for smaller runs or a scheduler submission pattern for longer cluster jobs.
+
+### Start downstream review with MultiQC, then move to merged counts
 
 The README emphasizes the output tree rather than individual intermediate commands. The key directories are `multiqc`, `fastqc`, `star_salmon`, and `trimgalore`, with merged gene counts and DESeq2-ready artifacts under `star_salmon`.
 
@@ -87,12 +89,17 @@ outdir/
 
 For this page, the main operational takeaway is: start with `multiqc`, then move to the merged counts and DESeq2-oriented outputs for downstream analysis.
 
+### Hand off the count outputs to downstream RNA-seq analysis
+
+The committed README stops at pipeline execution and output inspection, not differential expression itself. In practice, the main handoff is from `star_salmon/merged_gene_counts/` and related QC outputs into downstream DEG, PCA, and enrichment workflows.
+
 ## Gotchas / notes
 
 - This folder is README-driven and does not include a committed notebook or figure set, so the page stays concise.
 - The README uses example genomes (`GRCh38`, `GRCm38`); readers need to choose the right reference for their study.
 - Single-end data are allowed, but `fastq_2` must be left empty in the samplesheet.
 - The methods paragraph includes a placeholder version string for `nf-core/rnaseq`, so users should record the real version used in their run.
+- The samplesheet examples mix single-end and paired-end rows, so readers should confirm that their own sheet matches the library structure they actually sequenced.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/RNAseq_nfcore_workflow)

--- a/site/workflows/data-geo-submission.qmd
+++ b/site/workflows/data-geo-submission.qmd
@@ -29,13 +29,13 @@ Use this workflow when you are preparing a study for GEO submission and need a l
 
 ## Steps
 
-### Organize the submission package and fill in the metadata spreadsheet
+### Gather raw files, processed matrices, and the metadata spreadsheet
 
 The README starts from three required pieces: raw FASTQs, processed matrices, and the GEO metadata spreadsheet. It points to the committed Excel template as the example submission sheet.
 
 For RNA-seq and scRNA-seq submissions, the folder structure is expected to separate raw data from processed data, with compressed `counts.csv.gz` and `metadata.csv.gz` files recommended for transfer efficiency.
 
-### Export processed Seurat data to count and metadata tables
+### Export processed Seurat data if the deliverables still live in `combined.qsave`
 
 If your processed data still live inside a Seurat object, the helper R Markdown reads `combined.qsave`, sets the RNA assay, and writes the metadata and counts matrices to CSV.
 
@@ -51,7 +51,7 @@ write.csv(counts, "counts.csv", row.names = T, col.names = T, quote = F)
 
 This is a thin but useful branch for converting a Seurat object into the two processed matrices GEO usually expects.
 
-### Upload raw and processed files to GEO's private FTP area
+### Upload the prepared folder structure to GEO's private FTP area
 
 Once the data and spreadsheet are ready, the README directs you to GEO's sequence submission page and shows an `lftp`-based upload pattern for mirroring the prepared working directory into your temporary private GEO upload folder.
 
@@ -63,7 +63,9 @@ cd uploads/cankun.wang@orcid_6LOT6a04
 mirror -R .
 ```
 
-After the FTP transfer, the final step is uploading the metadata spreadsheet through GEO's web interface and waiting for accession assignment or curator feedback.
+### Finish the web submission and wait for accession assignment
+
+After the FTP transfer, the last step is returning to GEO's web interface to upload the metadata spreadsheet. The committed README notes that accession assignment may take about a week and that curator follow-up can require corrections before the submission is finalized.
 
 ## Gotchas / notes
 
@@ -71,6 +73,7 @@ After the FTP transfer, the final step is uploading the metadata spreadsheet thr
 - GEO FTP credentials are temporary and change frequently, so the example login values in the README are only placeholders.
 - `export_data.rmd` assumes a local `combined.qsave` Seurat object and does not include broader validation or formatting steps beyond writing CSVs.
 - The directory structure illustration referenced in the README is external rather than committed in this repo; the only committed template asset here is `seq_template.xlsx`.
+- The page reflects the practical handoff order in the README, but GEO-specific validation details still live outside this repository.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Data_GEO_submission)

--- a/site/workflows/data-sra.qmd
+++ b/site/workflows/data-sra.qmd
@@ -12,7 +12,7 @@ This workflow downloads SRA run accessions in parallel using SRA Toolkit. The co
 
 ## When to use it
 
-Use this workflow when you need to retrieve raw sequencing runs from SRA rather than supplementary files from GEO. It is most useful for batches of SRR accessions where parallel downloads and an HPC-friendly wrapper save time compared with running `fasterq-dump` one accession at a time.
+Use this workflow when you need to retrieve raw sequencing runs from SRA rather than supplementary files from GEO. It is most useful for batches of SRR accessions where parallel downloads and an HPC-friendly wrapper save time compared with running `fasterq-dump` one accession at a time, especially when the next step is a separate preprocessing workflow.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ Use this workflow when you need to retrieve raw sequencing runs from SRA rather 
 
 ## Steps
 
-### Prepare the SRA accession list and choose output directories
+### Prepare the SRR accession list and choose output locations
 
 The workflow expects a JSON file with the structure below, plus optional output and temporary directories passed on the command line.
 
@@ -47,7 +47,9 @@ The workflow expects a JSON file with the structure below, plus optional output 
 python fetch-with-sratoolkit.py -o /output -t /tmp ./sra_ids.json
 ```
 
-### Launch parallel `fasterq-dump` jobs from Python
+The main setup contract here is the JSON file. The script does not discover runs from a study accession on its own; it expects an explicit `sraIds` list.
+
+### Launch parallel `fasterq-dump` jobs from the Python wrapper
 
 The main script reads the SRR IDs from JSON, builds one `fasterq-dump` command per accession, and uses a multiprocessing pool of eight workers to run them.
 
@@ -60,9 +62,9 @@ with Pool(8) as p:
     result = p.map(execute_cmd, cmds)
 ```
 
-That makes this workflow a direct retrieval utility rather than a downstream preprocessing workflow.
+That makes this workflow a direct retrieval utility rather than a downstream preprocessing workflow: its job is to get the SRA runs onto disk efficiently, not to analyze them.
 
-### Run the same fetcher on OSC through the provided Slurm wrapper
+### Use the OSC batch wrapper for larger download jobs
 
 For the Ohio Supercomputer Center, the committed shell script loads Python and SRA Toolkit modules and launches the same Python fetcher as an eight-task batch job.
 
@@ -81,6 +83,10 @@ python ./fetch-with-sratoolkit.py -o ./ -t ./ ./sra_ids.json
 ```
 
 The README presents this as the main cluster integration pattern for larger downloads.
+
+### Hand off the downloaded runs to downstream preprocessing
+
+The committed materials stop at retrieval. Once the downloads are complete, the next step is to move into whichever workflow actually preprocesses the resulting files, rather than expecting this utility to perform QC or alignment itself.
 
 ## Gotchas / notes
 

--- a/site/workflows/scatac-chromvar.qmd
+++ b/site/workflows/scatac-chromvar.qmd
@@ -8,16 +8,22 @@ workflow:
 
 ## What it does
 
-This workflow computes transcription factor motif activity scores from a preprocessed snATAC-seq Seurat object using ChromVAR inside the Signac ecosystem. It adds motif annotations from JASPAR and stores per-cell motif deviation scores in a dedicated `chromvar` assay.
+This workflow computes transcription factor motif activity scores from a preprocessed snATAC-seq Seurat object using ChromVAR inside the Signac ecosystem. It adds JASPAR2020 motif annotations to the ATAC assay and stores per-cell motif deviation scores in a dedicated `chromvar` assay for downstream visualization or integrative analysis.
 
 ## When to use it
 
-Use this workflow when peak-level accessibility has already been processed and the next question is which TF motifs show differential accessibility patterns across cells. It is a focused downstream branch for motif activity rather than a full scATAC-seq pipeline.
+Use this workflow when peak-level accessibility has already been processed and the next question is which TF motifs show differential accessibility patterns across cells. It is a focused downstream branch for motif activity rather than a full scATAC-seq pipeline, and the committed example assumes a human hg38 object with ATAC counts in the `Macs_peaks` assay.
 
 ## Prerequisites
 
 - Source folder: [`scATACseq_ChromVAR_motif`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_ChromVAR_motif)
 - Main documentation: [`README.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/scATACseq_ChromVAR_motif/README.md)
+- Required packages called out in the README:
+  - `Signac`
+  - `ChromVAR`
+  - `motifmatchr`
+  - `JASPAR2020`
+  - `BiocParallel`
 - Required inputs:
   - `MultiOmic.qs` with ATAC counts in the `Macs_peaks` assay
   - `JASPAR2020`
@@ -25,23 +31,37 @@ Use this workflow when peak-level accessibility has already been processed and t
 
 ## Steps
 
-### Load the Seurat object and motif resources
+### Load the preprocessed ATAC object and set the peak assay
 
-The README expects a preprocessed Seurat object, the hg38 genome build, and motif definitions from the JASPAR CORE collection.
+The README assumes you are starting from a serialized Seurat object named `MultiOmic.qs` and that its ATAC counts live in the `Macs_peaks` assay. Before any motif work happens, this branch is already past primary preprocessing and clustering.
 
-### Add motifs and run ChromVAR
+The committed run sequence is:
 
-The documented branch is compact: retrieve motifs with `getMatrixSet()`, add them to the ATAC assay with `AddMotifs()`, and compute deviation scores with `RunChromVAR()`.
+```text
+read MultiOmic.qs
+set DefaultAssay(...) to Macs_peaks
+load BSgenome.Hsapiens.UCSC.hg38
+retrieve JASPAR CORE motifs
+```
 
-### Save the updated object
+### Retrieve the JASPAR CORE motif collection for the matching genome
 
-The output is a new `multi_chromvar.qs` object containing motif annotations and a `"chromvar"` assay for downstream visualization or integrative analysis.
+The README describes pulling human transcription factor motifs from the JASPAR CORE collection and pairing them with the hg38 genome reference before running ChromVAR. This genome-plus-motif pairing is the key setup contract for the workflow.
+
+### Add motifs and compute ChromVAR deviations
+
+Once motifs are loaded, the documented branch adds them to the Seurat object with `AddMotifs()` and then runs `RunChromVAR()` to calculate per-cell motif deviation scores. The resulting object keeps the original peak assay and adds a new `chromvar` assay that can be used for downstream feature plots, group comparisons, or integrative modeling with gene expression.
+
+### Save the updated Seurat object for downstream use
+
+The output is a new `multi_chromvar.qs` object containing motif annotations and ChromVAR deviation scores. This page stays concise because the committed source is a README rather than a notebook, but the intended handoff is clear: save the updated object and continue motif-level exploration elsewhere.
 
 ## Gotchas / notes
 
 - This workflow is intentionally thin in the committed source materials and does not include a notebook or committed figures.
 - The README notes that `SerialParam()` is used by default for reproducibility, with `MulticoreParam()` as an optional Unix parallelization path.
-- Genome build and motif collection need to match the assay and species.
+- Genome build and motif collection need to match the assay and species; the committed example is specifically human hg38.
+- Because the page is README-driven, it documents the function sequence and handoff rather than a richer rendered code walkthrough.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_ChromVAR_motif)

--- a/site/workflows/scatac-cicero.qmd
+++ b/site/workflows/scatac-cicero.qmd
@@ -25,7 +25,7 @@ Use this workflow when the main question is regulatory linkage between accessibl
 
 ## Steps
 
-### Load the tutorial data and create the ATAC CDS
+### Load the accessibility matrix and create a Cicero-compatible CDS
 
 The notebook starts by loading tutorial data and converting peak accessibility counts plus peak coordinates into a Cicero-compatible cell data set.
 
@@ -36,7 +36,7 @@ input_cds <- make_atac_cds(
 )
 ```
 
-### Reduce dimensions and prepare the embedding for aggregation
+### Reduce dimensions and build the embedding used for aggregation
 
 Before Cicero is run, the workflow detects features, estimates size factors, and computes a low-dimensional representation that will define neighborhood structure for cell aggregation.
 
@@ -51,7 +51,9 @@ input_cds <- reduceDimension(
 )
 ```
 
-### Aggregate nearby cells and run Cicero
+This is the transition from sparse raw accessibility data into the neighborhood structure Cicero needs for co-accessibility inference.
+
+### Aggregate nearby cells and calculate co-accessibility connections
 
 The core Cicero branch groups nearby cells and then computes co-accessibility relationships for genomic windows, using chromosome coordinates as the scaffold.
 
@@ -67,7 +69,9 @@ conns <- run_cicero(
 )
 ```
 
-### Filter connections, build CCANs, and derive gene activity
+The committed tutorial uses a chromosome subset in one branch for demonstration and runtime control, which is worth treating as a tutorial device rather than a default full-genome analysis mode.
+
+### Filter stronger connections, define CCANs, and derive gene activity
 
 After co-accessibility scores are computed, the notebook filters for stronger positive relationships, identifies CCANs, and computes gene activity scores from those networks.
 
@@ -77,10 +81,13 @@ ccan_list <- generate_ccans(positive_conns)
 gene_activity <- build_gene_activity_matrix(cicero_cds, conns)
 ```
 
+The practical handoff from this page is a set of co-accessibility connections, CCAN assignments, and gene-activity summaries that can be interpreted alongside the main scATAC analysis rather than replacing it.
+
 ## Gotchas / notes
 
 - The tutorial is oriented around Cicero's CDS and aggregation model, so it assumes preprocessing has already produced a usable accessibility matrix.
 - The notebook uses a subset of chromosome 18 for demonstration in one branch, which is useful for runtime control but not a full-genome default.
+- The README is broader than the current page in places, but the committed notebook remains the main source for concrete execution order.
 - This folder does not include a committed figure asset set beyond the rendered HTML output.
 
 ---

--- a/site/workflows/scatac-gene-activity.qmd
+++ b/site/workflows/scatac-gene-activity.qmd
@@ -8,11 +8,11 @@ workflow:
 
 ## What it does
 
-This workflow calculates gene activity scores and peak-gene regulatory scores from a scATAC-seq peak count matrix. It uses MAESTRO-based gene score calculations and returns gene-by-cell plus gene-by-peak summaries for downstream regulatory analysis.
+This workflow calculates gene activity scores and peak-gene regulatory scores from a scATAC-seq peak count matrix. It uses MAESTRO-based gene score calculations to produce both a gene-by-cell activity matrix and a gene-by-peak regulatory potential matrix for downstream regulatory analysis.
 
 ## When to use it
 
-Use this workflow when the input is already a peak-by-cell matrix and the next step is to derive gene-centric summaries from accessibility rather than to cluster cells. It is a focused utility page for turning peak counts into gene activity features.
+Use this workflow when the input is already a peak-by-cell matrix and the next step is to derive gene-centric summaries from accessibility rather than to cluster cells. It is a focused utility page for turning peak counts into gene activity features, not a full Signac preprocessing workflow.
 
 ## Prerequisites
 
@@ -22,10 +22,11 @@ Use this workflow when the input is already a peak-by-cell matrix and the next s
   - [`gene_active_score.Rmd`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/scATACseq_Gene_activity/gene_active_score.Rmd)
 - Required packages include `Seurat`, `MAESTRO`, `reticulate`, and `qs`
 - Input: a peak-by-cell matrix, with the notebook example loading a `.qsave` object
+- Key runtime choice from the source materials: set the organism parameter to `GRCh38` or `GRCm38`
 
 ## Steps
 
-### Load the peak count matrix and Python-backed dependencies
+### Load the peak count matrix and configure the Python-backed environment
 
 The notebook loads a serialized peak matrix, configures the Python environment through `reticulate`, and then computes a gene-by-cell activity matrix.
 
@@ -35,7 +36,13 @@ use_python("~/.local/share/r-miniconda/envs/r-reticulate/bin/python", required =
 pbmc.gene <- ATACCalculateGenescore(atac_matrix)
 ```
 
-### Compute peak-gene regulatory scores
+This first stage is doing two practical things at once: confirming the peak matrix can be read in R and making sure MAESTRO can find the Python environment it needs.
+
+### Calculate the gene-by-cell activity matrix
+
+The main output of the first branch is `pbmc.gene`, which represents gene activity scores for each cell. In the committed notebook, this object is printed directly and an optional `qsave()` line is left commented for users who want to persist the result.
+
+### Derive the gene-by-peak regulatory potential matrix
 
 The second branch defines a helper that passes an identity-style matrix into `ATACCalculateGenescore()` so the result becomes a gene-by-peak regulatory potential matrix instead of a gene-by-cell activity matrix.
 
@@ -53,11 +60,23 @@ CalGenePeakScore <- function(peak_count_matrix, organism = "GRCh38") {
 peak_gene_reg <- CalGenePeakScore(atac_matrix, "GRCh38")
 ```
 
+This is the part of the workflow that makes the page more than a simple format conversion: it reuses the same scoring machinery to summarize regulatory potential at the peak level, not just the cell level.
+
+### Save or hand off the two matrix outputs
+
+The committed materials describe two outputs for downstream use:
+
+- a gene-by-cell activity score matrix
+- a gene-by-peak regulatory matrix
+
+The example notebook prints both objects and includes a commented `qsave()` line for the gene activity matrix, so readers should plan their own output filenames and storage locations explicitly.
+
 ## Gotchas / notes
 
 - The committed notebook uses an absolute example-data path outside the repo, so users will need to replace that with their own matrix location.
 - This workflow is compact and does not include committed figures or a rendered HTML example.
 - The README explicitly calls out species selection (`GRCh38` vs `GRCm38`) as a key input parameter.
+- The source materials describe the outputs clearly, but they leave the final saved filenames mostly up to the user.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scATACseq_Gene_activity)

--- a/site/workflows/scrna-10x-flex.qmd
+++ b/site/workflows/scrna-10x-flex.qmd
@@ -8,11 +8,11 @@ workflow:
 
 ## What it does
 
-This workflow covers the preprocessing step for pooled 10x Genomics Flex scRNA-seq libraries. It focuses on turning one multiplexed FASTQ set into per-sample filtered feature-barcode matrices using `cellranger multi`.
+This workflow covers the preprocessing step for pooled 10x Genomics Flex scRNA-seq libraries. It focuses on turning one multiplexed FASTQ set into per-sample filtered feature-barcode matrices using `cellranger multi`, along with the configuration files and OSC batch submission pattern needed to launch the run.
 
 ## When to use it
 
-Use this workflow when your wet-lab setup produced a 10x Flex experiment with multiple samples pooled into the same sequencing files. It is meant for the preprocessing stage only, before clustering or downstream single-cell analysis.
+Use this workflow when your wet-lab setup produced a 10x Flex experiment with multiple samples pooled into the same sequencing files. It is meant for the preprocessing stage only, before clustering or downstream single-cell analysis, and it is most useful when the main challenge is correctly mapping wet-lab sample metadata into the 10x `multi` configuration.
 
 ## Prerequisites
 
@@ -29,13 +29,22 @@ Use this workflow when your wet-lab setup produced a 10x Flex experiment with mu
 
 ## Steps
 
-### Prepare the Flex `multi` configuration
+### Build the `cellranger multi` CSV from the wet-lab sample sheet
 
-The README treats the configuration CSV as the key handoff between the wet-lab sample sheet and Cell Ranger. It maps the raw FASTQ identifier, FASTQ directory, reference, probe set, sample IDs, and probe barcode IDs into one file for `cellranger multi`.
+The README treats the configuration CSV as the key handoff between the wet-lab sample sheet and Cell Ranger. It maps the raw FASTQ identifier, FASTQ directory, reference, probe set, sample IDs, probe barcode IDs, and sample descriptions into one file for `cellranger multi`.
 
-### Submit the Cell Ranger job on OSC
+That mapping step is the core decision point in this workflow: once the CSV is correct, Cell Ranger can demultiplex pooled Flex data and write per-sample outputs without additional custom preprocessing code.
 
-The committed Slurm script is an OSC-style example that sets account, runtime, memory, working directory, and the `cellranger multi` command.
+### Pair the configuration CSV with an OSC batch script
+
+The committed Slurm script is an OSC-style example that sets account, runtime, memory, working directory, and the `cellranger multi` command. In practice, the workflow is driven by two companion files:
+
+- the `multi` configuration CSV
+- a batch script that points `cellranger multi` at that CSV
+
+This keeps the run command simple while making the metadata and demultiplexing settings explicit in the CSV.
+
+### Submit the Flex preprocessing job on OSC
 
 ```bash
 #!/usr/bin/bash
@@ -50,7 +59,9 @@ cd /fs/ess/PAS2505/230801_Grayson_GSL-RH-3496/alignment/alignment_epi_data
 ${CellRanger} multi --id=Y12696_GraysonM_Naive-i_V1G_1 --csv=Y12696_GraysonM_Naive-i_V1G_1.csv --localcores=8 --localmem=64
 ```
 
-### Collect the filtered matrix and alignment summary
+The README also notes that the Slurm output file is the main place to monitor real-time run status after submission.
+
+### Review the per-sample summaries and collect filtered matrices
 
 The documented outputs are per-sample `web_summary.html` reports and filtered feature-barcode matrices suitable for downstream Seurat or Scanpy workflows.
 
@@ -61,11 +72,14 @@ sample_filtered_feature_bc_matrix/
 └── matrix.mtx.gz
 ```
 
+The practical handoff from this page is straightforward: once `cellranger multi` finishes, move from the `web_summary.html` reports into the per-sample filtered matrices for downstream QC, clustering, or format conversion in other workflows.
+
 ## Gotchas / notes
 
 - The CSV content is the critical sample-demultiplexing input; mismatched probe barcode IDs or sample descriptions will propagate into the output.
 - The committed paths are OSC-specific examples and should be adapted to the actual project storage and account.
 - The README includes an externally hosted screenshot of the CSV layout, but there are no committed local figure assets in this workflow folder.
+- This page only covers pooled Flex preprocessing; downstream single-cell analysis happens in other workflow folders.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_10x_Flex_preprocessing)

--- a/site/workflows/scrna-infercnv.qmd
+++ b/site/workflows/scrna-infercnv.qmd
@@ -8,11 +8,11 @@ workflow:
 
 ## What it does
 
-This workflow prepares a clustered scRNA-seq object for inferCNV and runs CNV inference with denoising and HMM enabled. Its goal is to distinguish likely malignant or aneuploid cells from diploid reference populations using expression-derived copy-number patterns.
+This workflow prepares a clustered scRNA-seq object for inferCNV and runs CNV inference with denoising and HMM enabled. Its goal is to distinguish likely malignant or aneuploid cells from diploid reference populations using expression-derived copy-number patterns and save the resulting heatmaps and CNV calls into a dedicated output folder.
 
 ## When to use it
 
-Use this workflow when you already have a preprocessed Seurat object and a suitable gene-order file and want a branch for tumor-versus-reference CNV screening. It is most relevant after clustering, when a plausible normal reference cluster can be identified.
+Use this workflow when you already have a preprocessed Seurat object and a suitable gene-order file and want a branch for tumor-versus-reference CNV screening. It is most relevant after clustering, when a plausible normal reference cluster can be identified and treated as the diploid baseline for the inferCNV run.
 
 ## Prerequisites
 
@@ -40,7 +40,9 @@ this_meta <- data.frame(cell = rownames(combined@meta.data), cluster = as.charac
 this_expr <- GetAssayData(combined, assay = "RNA", slot = "counts")
 ```
 
-### Create the inferCNV object
+This preparation step is what turns a general Seurat object into the two inputs inferCNV actually expects: a raw count matrix and a per-cell annotation table.
+
+### Choose the reference cluster and create the inferCNV object
 
 The committed example uses cluster `"11"` as the normal reference group and points inferCNV to a gene-order file based on hg38.
 
@@ -53,6 +55,8 @@ infercnv_obj <- CreateInfercnvObject(
   ref_group_names = c("11")
 )
 ```
+
+The reference-cluster choice is the main biological decision in this branch. The example cluster `"11"` is useful as a template, but the underlying requirement is simply that the chosen cluster should represent the diploid population you want to compare against.
 
 ### Run inferCNV with denoising and HMM enabled
 
@@ -70,10 +74,15 @@ infercnv_obj <- infercnv::run(
 )
 ```
 
+### Review the saved CNV outputs in the run directory
+
+The README describes the output directory as containing CNV heatmaps, cluster assignments, inferred CNV profiles, and other inferCNV diagnostic files. This page stays concise because the repo does not include committed local figures from a completed run, but the intended handoff is clear: inspect the generated inferCNV directory rather than expecting results to remain only in memory.
+
 ## Gotchas / notes
 
 - The README explicitly notes that this tutorial cannot be run on OSC because `infercnv` was not installable there in the tested environment.
 - The reference cluster choice is experiment-specific; the committed example's cluster `"11"` should not be treated as a universal default.
+- The output directory name `./infercnv_1` is an example run target, not a mandatory convention.
 - This workflow has no committed local figure assets, so the site page relies on the README and script content only.
 
 ---

--- a/site/workflows/scrna-label-transfer.qmd
+++ b/site/workflows/scrna-label-transfer.qmd
@@ -8,11 +8,11 @@ workflow:
 
 ## What it does
 
-This workflow groups together atlas-based label transfer notebooks for annotating new scRNA-seq datasets. The committed materials emphasize HLCA-based lung annotation and a more general reference-to-query transfer pattern using Seurat or SCANVI-style tooling.
+This workflow groups together atlas-based label transfer notebooks for annotating new scRNA-seq datasets. The committed materials emphasize HLCA-based lung annotation and a more general reference-to-query transfer pattern using Seurat- or SCANVI-style tooling.
 
 ## When to use it
 
-Use this workflow when clustering is complete but biological labels still need to be transferred from a curated reference atlas. It is most useful for lung datasets or for projects that already have a trusted annotated reference object.
+Use this workflow when clustering is complete but biological labels still need to be transferred from a curated reference atlas. It is most useful for lung datasets or for projects that already have a trusted annotated reference object and want a branch notebook focused on transferring labels rather than redoing preprocessing from scratch.
 
 ## Prerequisites
 
@@ -22,39 +22,57 @@ Use this workflow when clustering is complete but biological labels still need t
   - [`Introduction of annotating new lung datasets using HLCA.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/scRNAseq_label_transfer_branch/Introduction%20of%20annotating%20new%20lung%20datasets%20using%20HLCA.md)
   - [`HLCA_atlas_annotation.ipynb`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/scRNAseq_label_transfer_branch/HLCA_atlas_annotation.ipynb)
   - [`scRNAseq_label_transfer.ipynb`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/scRNAseq_label_transfer_branch/scRNAseq_label_transfer.ipynb)
-- Expected inputs: a query dataset plus a pre-annotated reference atlas
+- Expected inputs:
+  - a query dataset
+  - a pre-annotated reference atlas
+  - metadata with sample and batch information for the HLCA-oriented path
+- File formats explicitly mentioned in the committed materials include `.h5ad`, `.loom`, and `.rds`
 
 ## Steps
 
-### Prepare the query and reference inputs
+### Choose the notebook that matches your reference setup
 
-The README describes the core inputs as a processed query matrix, a pre-annotated reference dataset, and metadata needed for preprocessing and batch handling.
+This folder contains two parallel entry points rather than one monolithic tutorial:
 
-### Use the HLCA-specific notebook for lung datasets
+- `HLCA_atlas_annotation.ipynb` for Human Lung Cell Atlas-based annotation
+- `scRNAseq_label_transfer.ipynb` for a more general reference-to-query transfer pattern
 
-The HLCA branch is intended for Human Lung Cell Atlas-based annotation, aligning a new query dataset to the reference before transferring labels.
+Both expect a processed query dataset plus a curated annotated reference. The HLCA notes also call out metadata with sample and batch information.
 
-```text
-Notebook: HLCA_atlas_annotation.ipynb
-Inputs: query scRNA-seq matrix + preprocessed HLCA reference
-Outputs: transferred cell type labels + visualization plots
-```
+### Use the HLCA notebook for lung-specific annotation
 
-### Use the general label-transfer notebook for other references
-
-The second notebook covers a broader transfer pattern using reference/query integration, predicted labels, and confidence checks.
+The HLCA branch is intended for lung datasets and the committed README summarizes its workflow as:
 
 ```text
-Notebook: scRNAseq_label_transfer.ipynb
-Inputs: query dataset + annotated reference dataset
-Outputs: predicted labels, confidence summaries, and integrated UMAP views
+load and preprocess the query dataset
+align query data to the HLCA reference with PCA and Harmony integration
+transfer labels with scANVI or Symphony
+generate visualization plots
 ```
+
+The short HLCA introduction file reinforces the same scope: query scRNA-seq input, a pre-annotated HLCA reference, supporting metadata, and per-cell cell type annotations as output.
+
+### Use the general notebook for non-HLCA references
+
+The second notebook covers a broader label-transfer pattern that is not specific to lung atlases. The committed README describes it as:
+
+```text
+normalize and log-transform the query data
+integrate query and reference with PCA/CCA (Seurat) or variational inference (SCANVI)
+transfer labels and assess confidence
+visualize the combined embedding
+```
+
+### Review the transferred labels, confidence summaries, and embeddings
+
+Across both notebooks, the intended deliverables are the same: predicted cell type labels on the query dataset plus visualization outputs that let you inspect whether the reference mapping looks plausible. This page stays at the routing-and-rationale level because the implementation details live inside the committed Jupyter notebooks rather than in rendered markdown.
 
 ## Gotchas / notes
 
 - The committed source material for this workflow is thinner than some other `scrna` folders: the README is high-level, and most implementation detail lives inside Jupyter notebooks.
 - There are no committed local figure assets in this folder.
 - The HLCA note is lung-focused, so projects outside that assay/tissue context will likely rely more heavily on the general notebook.
+- The HLCA introduction file is very brief and partially incomplete, so the notebooks themselves remain the main source for execution detail.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_label_transfer_branch)

--- a/site/workflows/scrna-seurat-scanpy.qmd
+++ b/site/workflows/scrna-seurat-scanpy.qmd
@@ -8,11 +8,11 @@ workflow:
 
 ## What it does
 
-This workflow converts an R Seurat object into a Scanpy-compatible `.h5ad` file. It uses `SeuratDisk` to save an intermediate `.h5Seurat` file and then convert that object into AnnData format.
+This workflow converts an R Seurat object into a Scanpy-compatible `.h5ad` file. It uses `SeuratDisk` to save an intermediate `.h5Seurat` file and then convert that object into AnnData format, preserving the chosen assay and Seurat metadata in the exported object.
 
 ## When to use it
 
-Use this workflow when the upstream analysis was performed in Seurat but the next step needs to happen in Python or Scanpy. It is a compact format-conversion utility rather than a full analysis notebook.
+Use this workflow when the upstream analysis was performed in Seurat but the next step needs to happen in Python or Scanpy. It is a compact format-conversion utility rather than a full analysis notebook, and it is most helpful when you need a clear reminder of which Seurat assay becomes the primary AnnData matrix.
 
 ## Prerequisites
 
@@ -22,10 +22,11 @@ Use this workflow when the upstream analysis was performed in Seurat but the nex
   - [`seurat_to_scanpy.R`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/scRNAseq_Seurat_to_Scanpy/seurat_to_scanpy.R)
 - Required packages include `qs`, `Seurat`, and `SeuratDisk`
 - Input: a Seurat object, commonly stored as `combined.qsave`
+- Version caveat from the committed README: the tested path assumes Seurat versions below v5 because `SeuratDisk` support was limited at the time of testing
 
 ## Steps
 
-### Load and update the Seurat object
+### Load the Seurat object and update it before export
 
 The script reads a `.qsave` object, updates it if needed, and sets the assay that should become the main expression layer in the exported `.h5ad`.
 
@@ -38,6 +39,15 @@ DefaultAssay(combined) <- "RNA"
 # or DefaultAssay(combined) <- "SCT"
 ```
 
+### Choose the assay intentionally before conversion
+
+The README makes the assay choice the main decision point in this workflow:
+
+- if `RNA` is the default assay, the export writes RNA normalized data to `X` and RNA counts to `raw`
+- if `SCT` is the default assay, the export changes which matrix becomes the primary layer
+
+That choice determines what Scanpy will treat as the main expression matrix after import, so it should match the downstream Python analysis you actually plan to run.
+
 ### Export to `.h5Seurat` and convert to `.h5ad`
 
 The conversion itself is a two-step handoff through SeuratDisk.
@@ -47,14 +57,15 @@ SaveH5Seurat(combined, filename = "combined.h5Seurat", overwrite = TRUE)
 Convert("combined.h5Seurat", dest = "h5ad", overwrite = TRUE)
 ```
 
-### Choose the assay intentionally
+### Check metadata and export separate variants if needed
 
-The README notes that exporting `RNA` places normalized data in `X` and counts in `raw`, while exporting `SCT` changes which layer becomes the primary matrix.
+The committed script and README both suggest a small amount of cleanup may be needed before import on the Python side. In particular, the script comments note that metadata columns containing all `NA` values can cause problems and may need to be removed before writing the `.h5Seurat` file. The README also explicitly notes that you can export different assays separately if you want multiple H5AD variants.
 
 ## Gotchas / notes
 
 - The README explicitly warns that the tested path uses Seurat below v5 because `SeuratDisk` support was limited at the time of testing.
 - The committed script includes comments about clearing metadata columns with all-`NA` values if Scanpy import errors occur.
+- The committed script uses `combined` for the loaded object but also shows `DefaultAssay(seu) <- "SCT"` in one line, so readers should treat that as a source inconsistency and apply the assay choice to the object they actually loaded.
 - This workflow is intentionally thin: it contains a script and README, but no committed local figures or rendered screenshots.
 
 ---

--- a/site/workflows/scrna-shinycell.qmd
+++ b/site/workflows/scrna-shinycell.qmd
@@ -8,11 +8,11 @@ workflow:
 
 ## What it does
 
-This workflow exports a pre-analyzed Seurat object into a ShinyCell application. It generates the app files needed for interactive exploration of metadata, embeddings, and gene expression outside the notebook environment.
+This workflow exports a pre-analyzed Seurat object into a ShinyCell application. It generates the app files needed for interactive exploration of metadata, embeddings, and gene expression outside the notebook environment and packages them into a directory that can be archived for deployment.
 
 ## When to use it
 
-Use this workflow when analysis is already complete and the next goal is to share results with collaborators through a hosted viewer. It is a deployment-oriented utility rather than a preprocessing or modeling workflow.
+Use this workflow when analysis is already complete and the next goal is to share results with collaborators through a hosted viewer. It is a deployment-oriented utility rather than a preprocessing or modeling workflow, and it is most useful once the Seurat object is already cleaned, annotated, and ready to present.
 
 ## Prerequisites
 
@@ -25,9 +25,13 @@ Use this workflow when analysis is already complete and the next goal is to shar
 
 ## Steps
 
-### Load the processed Seurat object and initialize ShinyCell config
+### Point the notebook at the `.qsave` object you want to publish
 
-The notebook reads `combined.qsave`, builds a ShinyCell config object, and leaves room to remove or rename metadata before export.
+The notebook uses a small `sample_list` vector to define the Seurat objects that should feed the app. In the committed example, that list contains `./combined`, which is then read as `combined.qsave`.
+
+### Build the ShinyCell configuration and review metadata choices
+
+After loading the object, the notebook creates a ShinyCell config object and leaves several optional customization hooks in comments. These include deleting metadata columns, renaming metadata for display, and changing color mappings before the app is written out.
 
 ```r
 seu <- qs::qread(paste0(this_sample_name, ".qsave"))
@@ -35,7 +39,9 @@ scConf1 <- createConfig(seu)
 # scConf1 <- delMeta(scConf1, c("orig.ident", "RNA_snn_res.0.2"))
 ```
 
-### Generate the Shiny app files
+This is the part of the workflow where presentation choices happen, so it is worth reviewing the metadata fields before generating files for collaborators.
+
+### Generate the ShinyCell app files with the desired defaults
 
 The core export step writes the app bundle into `shinyAppMulti/`, including default genes and the embedding coordinates that should appear first in the app.
 
@@ -55,7 +61,9 @@ makeShinyFiles(
 )
 ```
 
-### Build the multi-sample wrapper and archive for deployment
+The committed example uses hard-coded default genes (`Nrgn`, `Gad1`, `Gad2`) and the RNA assay's `data` slot, which are practical defaults to revisit for a different project.
+
+### Build the multi-sample wrapper and archive the app directory for deployment
 
 The notebook finishes by generating the Shiny code wrapper. The README instructs users to archive `shinyAppMulti/` and coordinate deployment to the BMBL server.
 
@@ -73,7 +81,8 @@ makeShinyCodesMulti(
 
 - This workflow assumes the Seurat object is already fully annotated and ready for sharing; it does not perform any upstream analysis.
 - The committed example uses hard-coded default genes and a fixed output directory that you will usually want to review before deployment.
-- There are no committed local screenshots in this folder, but the README includes a live demo link to an already deployed ShinyCell app.
+- There are no committed local screenshots in this folder, but the README includes a live demo link that shows the intended type of end result.
+- Deployment is still a manual handoff in the committed materials: archive `shinyAppMulti/` and coordinate server deployment separately.
 
 ---
 [📄 View source on GitHub](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/scRNAseq_ShinyCell_portal)

--- a/site/workflows/spatial-neighborhood.qmd
+++ b/site/workflows/spatial-neighborhood.qmd
@@ -8,16 +8,17 @@ workflow:
 
 ## What it does
 
-This workflow focuses on cellular-neighborhood analysis in the immune tumor microenvironment rather than on primary spatial preprocessing. The committed README describes a Python notebook-based method for identifying major components of association between cell types and cellular neighborhoods from an annotated table.
+This workflow focuses on cellular-neighborhood analysis in the immune tumor microenvironment rather than on primary spatial preprocessing. The committed README describes a Python notebook-based method for identifying major components of association between cell types and cellular neighborhoods from an already annotated table.
 
 ## When to use it
 
-Use this workflow when the upstream spatial or imaging data have already been annotated with cell types and neighborhood labels, and the next question is how neighborhoods relate to cell-type composition across samples or patient groups. It is a focused downstream analysis branch rather than a full spatial transcriptomics pipeline.
+Use this workflow when the upstream spatial or imaging data have already been annotated with cell types and neighborhood labels, and the next question is how neighborhoods relate to cell-type composition across samples or patient groups. It is a focused downstream analysis branch rather than a full spatial transcriptomics pipeline, and it assumes the neighborhood annotation step has already happened elsewhere.
 
 ## Prerequisites
 
 - Source folder: [`Spatial_Cellular_neighborhood`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/Spatial_Cellular_neighborhood)
 - Main documentation: [`readme.md`](https://github.com/OSU-BMBL/BMBL-analysis-notebooks/blob/master/Spatial_Cellular_neighborhood/readme.md)
+- Main implementation note in the README: download the Python notebook separately and run it in Jupyter
 - Expected input table columns:
   - `patients`
   - optional `groups`
@@ -28,17 +29,30 @@ Use this workflow when the upstream spatial or imaging data have already been an
 
 ## Steps
 
-### Prepare the annotated input table
+### Prepare an annotated CSV with the required columns
 
 The README makes the input contract explicit: the CSV must already contain sample identifiers, neighborhood labels, and cell-type annotations.
 
-### Open the Python notebook and update the data path
+The required columns listed in the committed source are:
+
+- `patients`
+- optional `groups`
+- `neighborhood10`
+- `ClusterName`
+
+### Open the notebook and point `path_to_data` at the CSV file
 
 The committed instructions say to download the Python code, open it in Jupyter, and change `path_to_data` to point to the CSV file.
 
-### Run the notebook sequentially to summarize neighborhoods
+### Run the notebook sequentially to summarize neighborhood associations
 
 The intended outcome is to identify the main associations between cell types and cellular neighborhoods in the tumor microenvironment.
+
+This page stays concise because the repository only commits the README, not the notebook itself. The source materials make the operational sequence clear even if they do not expose the intermediate code cells on the site.
+
+### Use the sample dataset and cited paper as context, not as in-repo assets
+
+The README links to an external sample file, `CRC_clusters_neighborhoods_markers.csv`, and to the original publication for methodological detail. Those references are useful for understanding the expected input shape and the intended analysis context, but they are external resources rather than committed local assets.
 
 ## Gotchas / notes
 


### PR DESCRIPTION
## Summary

This PR deepens the internal workflow-page refinement pass without changing scientific logic or expanding the site beyond its Tier B usage-and-rationale scope.

It focuses on:
- strengthening weaker internal workflow pages with clearer step framing and more explicit handoff language
- improving consistency across README-driven utility and branch pages
- updating the homepage copy so it reflects the current fully internalized site instead of the earlier pilot-era framing

## High-priority pages refined

- scRNA-seq 10x Flex preprocessing
- inferCNV
- SRA download
- bulk RNA-seq nf-core
- bulk ATAC-seq nf-core
- HOMER motif analysis
- bulk ChIP-seq workflow v2
- scATAC-seq Cicero branch

## Additional workflow pages retained from the first refinement pass

- bulk ChIP-seq workflow
- GEO submission
- ChromVAR motif activity
- scATAC gene activity
- label transfer
- Seurat to Scanpy conversion
- ShinyCell portal export
- spatial cellular neighborhood

## Homepage update

- revised `index.qmd` so the landing page no longer references the site as a pilot/incomplete migration
- clarified that the workflow catalog is internalized and that pages are static reference pages built from committed repo materials

## What changed

- made step titles more specific and outcome-oriented
- clarified what each thinner workflow expects as input and what it produces as output/handoff
- surfaced source limitations more explicitly where workflows are README-only, notebook-driven, or dependent on external assets
- tightened wording that still read like migration scaffolding
- improved consistency across workflow families without doing a whole-catalog rewrite

## Intentionally left mostly as-is

- stronger benchmark pages such as the general scRNA, scATAC, and spatial workflows
- pages where the committed source was already close to the target quality bar

## Remaining thin-source areas

Some workflows are still inherently limited by the committed source material. In particular:
- notebook-driven or README-only branches where the repository does not expose much implementation detail in site-friendly form
- workflows that depend on external datasets, external screenshots, or incomplete notebook context

Those pages were cleaned up and clarified, but not padded with invented details.

## Validation

- ran `python3 scripts/build_site_catalog.py`
- ran `quarto render`
- reviewed the homepage and changed workflow pages in the rendered local site
- confirmed changed pages preserved the fixed section structure:
  - `What it does`
  - `When to use it`
  - `Prerequisites`
  - `Steps`
  - `Gotchas / notes`