### PR TITLE
Fix latent bugs in site build tooling & validator (#25 follow-up)

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -30,7 +30,7 @@ jobs:
         run: python3 scripts/build_site_catalog.py
 
       - name: Verify generated artifacts are committed
-        run: git diff --exit-code -- _quarto.yml _generated/workflow-catalog.qmd
+        run: git diff --exit-code -- _quarto.yml _generated/workflow-catalog.qmd _generated/category-jump-links.qmd
 
       - name: Render site
         run: quarto render

--- a/scripts/build_site_catalog.py
+++ b/scripts/build_site_catalog.py
@@ -59,14 +59,22 @@ def dump_scalar(value):
     return json.dumps(str(value))
 
 
+def empty_flow(value):
+    # An empty mapping/sequence must be emitted inline; a bare "key:" parses as null.
+    return "{}" if isinstance(value, dict) else "[]"
+
+
 def dump_yaml(value, indent=0):
     space = " " * indent
     lines = []
     if isinstance(value, dict):
         for key, item in value.items():
             if isinstance(item, (dict, list)):
-                lines.append(f"{space}{key}:")
-                lines.append(dump_yaml(item, indent + 2))
+                if not item:
+                    lines.append(f"{space}{key}: {empty_flow(item)}")
+                else:
+                    lines.append(f"{space}{key}:")
+                    lines.append(dump_yaml(item, indent + 2))
             else:
                 lines.append(f"{space}{key}: {dump_scalar(item)}")
     elif isinstance(value, list):
@@ -79,20 +87,29 @@ def dump_yaml(value, indent=0):
                 first = keys[0]
                 first_value = item[first]
                 if isinstance(first_value, (dict, list)):
-                    lines.append(f"{space}- {first}:")
-                    lines.append(dump_yaml(first_value, indent + 4))
+                    if not first_value:
+                        lines.append(f"{space}- {first}: {empty_flow(first_value)}")
+                    else:
+                        lines.append(f"{space}- {first}:")
+                        lines.append(dump_yaml(first_value, indent + 4))
                 else:
                     lines.append(f"{space}- {first}: {dump_scalar(first_value)}")
                 for key in keys[1:]:
                     child = item[key]
                     if isinstance(child, (dict, list)):
-                        lines.append(f"{space}  {key}:")
-                        lines.append(dump_yaml(child, indent + 4))
+                        if not child:
+                            lines.append(f"{space}  {key}: {empty_flow(child)}")
+                        else:
+                            lines.append(f"{space}  {key}:")
+                            lines.append(dump_yaml(child, indent + 4))
                     else:
                         lines.append(f"{space}  {key}: {dump_scalar(child)}")
             elif isinstance(item, list):
-                lines.append(f"{space}-")
-                lines.append(dump_yaml(item, indent + 2))
+                if not item:
+                    lines.append(f"{space}- []")
+                else:
+                    lines.append(f"{space}-")
+                    lines.append(dump_yaml(item, indent + 2))
             else:
                 lines.append(f"{space}- {dump_scalar(item)}")
     else:
@@ -153,7 +170,6 @@ def validate_catalog(catalog):
         category_ids.add(cid)
 
     workflow_ids = set()
-    featured = []
     navbar = []
     for workflow in workflows:
         wid = workflow["id"]
@@ -196,13 +212,9 @@ def validate_catalog(catalog):
                     f"found {workflow_meta.get('repo_path')}"
                 )
 
-        if workflow.get("featured"):
-            featured.append(wid)
         if workflow.get("navbar"):
             navbar.append(wid)
 
-    if len(featured) > 1:
-        raise SystemExit(f"Only one workflow can be featured. Found: {', '.join(featured)}")
     if len(navbar) > 1:
         raise SystemExit(f"Only one workflow can appear in the navbar workflow slot. Found: {', '.join(navbar)}")
 

--- a/site/catalog.yml
+++ b/site/catalog.yml
@@ -235,7 +235,6 @@ workflows:
     repo_path: "_Archived/RNAseq_workflow"
     page: "rnaseq-workflow.qmd"
     order: 10
-    featured: true
     navbar: true
     navbar_text: "Featured workflow"
   - id: bulk-rnaseq-nfcore

--- a/validate_repo.R
+++ b/validate_repo.R
@@ -36,6 +36,9 @@ check_warn <- function(msg) {
 }
 
 read_text_file <- function(path) {
+  if (!file.exists(path)) {
+    return("")
+  }
   paste(readLines(path, warn = FALSE), collapse = "\n")
 }
 
@@ -127,17 +130,27 @@ cat("\n")
 
 # 3a. Check generated website files and site catalog alignment
 cat("3a. Checking generated website files...\n")
-site_check <- system2(
-  "python3",
-  c("scripts/build_site_catalog.py", "--check"),
-  stdout = TRUE,
-  stderr = TRUE
-)
-
-if (is.null(attr(site_check, "status"))) {
-  check_pass("Generated site files and catalog are in sync")
+if (!nzchar(Sys.which("python3"))) {
+  check_warn("python3 not found - skipping generated-site catalog sync check")
 } else {
-  check_fail(paste(site_check, collapse = "\n"))
+  site_check <- tryCatch(
+    system2(
+      "python3",
+      c("scripts/build_site_catalog.py", "--check"),
+      stdout = TRUE,
+      stderr = TRUE
+    ),
+    error = function(e) structure(
+      paste("Could not run build_site_catalog.py:", conditionMessage(e)),
+      status = 1L
+    )
+  )
+
+  if (is.null(attr(site_check, "status"))) {
+    check_pass("Generated site files and catalog are in sync")
+  } else {
+    check_fail(paste(site_check, collapse = "\n"))
+  }
 }
 cat("\n")
 
@@ -182,6 +195,10 @@ cat("\n")
 # 5. Check site workflow pages
 cat("5. Checking site workflow pages...\n")
 for (page in workflow_pages()) {
+  if (!file.exists(page)) {
+    check_fail(paste(page, "is referenced but does not exist"))
+    next
+  }
   text <- read_text_file(page)
   front_matter <- extract_front_matter(text)
 
@@ -190,26 +207,31 @@ for (page in workflow_pages()) {
     next
   }
 
-  if (grepl("workflow:\\s*", front_matter, perl = TRUE)) {
+  # Anchor to a top-level `workflow:` key with indented children, so a stray
+  # top-level `id:`/`repo_path:` (or the word "workflow:" in prose) cannot pass.
+  if (grepl("(?m)^workflow:[ \\t]*$", front_matter, perl = TRUE)) {
     check_pass(paste(page, "has workflow metadata"))
   } else {
     check_fail(paste(page, "is missing workflow metadata block"))
   }
 
-  if (grepl("workflow:\\s*[\\s\\S]*?id:\\s*\"?[A-Za-z0-9-]+\"?", front_matter, perl = TRUE)) {
+  if (grepl("(?m)^[ \\t]+id:\\s*\"?[A-Za-z0-9_-]+\"?", front_matter, perl = TRUE)) {
     check_pass(paste(page, "has workflow.id"))
   } else {
     check_fail(paste(page, "is missing workflow.id"))
   }
 
-  if (grepl("workflow:\\s*[\\s\\S]*?repo_path:\\s*\"?[^\n\"]+\"?", front_matter, perl = TRUE)) {
+  if (grepl("(?m)^[ \\t]+repo_path:\\s*\"?[^\n\"]+\"?", front_matter, perl = TRUE)) {
     check_pass(paste(page, "has workflow.repo_path"))
   } else {
     check_fail(paste(page, "is missing workflow.repo_path"))
   }
 
   for (heading in required_site_headings) {
-    if (grepl(heading, text, fixed = TRUE)) {
+    # Anchor to a whole line so a deeper level (`### Prerequisites`) or a
+    # reworded heading (`## What it does differently`) does not falsely pass.
+    heading_pattern <- paste0("(?m)^", heading, "[ \\t]*$")
+    if (grepl(heading_pattern, text, perl = TRUE)) {
       check_pass(paste(page, "contains", heading))
     } else {
       check_fail(paste(page, "is missing", heading))


### PR DESCRIPTION
Fixes the six latent issues flagged in the #25 review follow-up. All were latent — none affected the committed site — but the first will bite the moment a new empty category is added.

## Fixes
1. **`build_site_catalog.py` `dump_yaml` — empty container → YAML null.** An empty list/dict was serialized as a bare `key:` (parses as `null`). Now emits `[]` / `{}`. Impact: adding a new catalog category before its first workflow page would have written `contents: null` into the `_quarto.yml` sidebar. Guarded all four recursion sites via a small `empty_flow()` helper.
2. **`build_site_catalog.py` — dead `featured` flag removed.** It was validated (`≤1`) but never consumed; the homepage card is static text. Removed the validation and the now-orphaned `featured: true` in `catalog.yml`. The navbar item is still driven by the consumed `navbar`/`navbar_text` fields.
3. **`validate_repo.R` heading check — anchored.** Was an unanchored `fixed=TRUE` substring, so `### Prerequisites` (h3) or `## What it does differently` falsely passed. Now anchored to a whole line.
4. **`validate_repo.R` front-matter checks — anchored.** `workflow:` / `id:` / `repo_path:` were matched anywhere; now `workflow:` must be a top-level key line with indented `id:`/`repo_path:`, so a stray top-level key or the word in prose can't satisfy them.
5. **`validate_repo.R` robustness.** `read_text_file()` now guards existence, and the section-3a `python3` call checks `Sys.which("python3")` and is wrapped in `tryCatch` — a missing page or a python-only runner reports cleanly instead of aborting the whole script.
6. **`publish-site.yml` drift guard.** Now also diffs `_generated/category-jump-links.qmd` (previously only 2 of the 3 generated files were checked).

## Verification
- `python3 scripts/build_site_catalog.py --check` → exit 0 (no drift introduced).
- `Rscript validate_repo.R` → exit 0, 0 errors.
- Behavioral checks confirm the anchored patterns **reject** the bad inputs (`### Prerequisites`, top-level `id:`, `workflow:` in prose) while still **accepting** the real pages, and that empty containers now emit `[]` / `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6urrSGfxKSGaVSPx5JJBn
