### PR TITLE
Improve Quarto site responsiveness and bugfix pass

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,9 @@ kbd {
   background: var(--panel-alt);
   color: var(--graphite);
   padding: 0.08rem 0.32rem;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 code,
@@ -284,9 +287,11 @@ pre,
 }
 
 main.content {
-  max-width: var(--content-width);
-  margin: 0 auto;
+  width: 100%;
+  max-width: none;
+  margin: 0;
   padding: 1rem 1.6rem 3.2rem;
+  min-width: 0;
 }
 
 h1,
@@ -689,12 +694,29 @@ pre,
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
   background: var(--code-bg);
+  max-width: 100%;
 }
 
 pre code,
 .sourceCode code {
   background: transparent;
   color: inherit;
+}
+
+pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.sourceCode {
+  overflow-x: auto;
+}
+
+.sourceCode pre,
+.sourceCode code,
+.sourceCode span {
+  max-width: 100%;
 }
 
 div.code-copy-outer-scaffold {
@@ -1324,6 +1346,41 @@ a[href^="https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/"]::aft
 @media (max-width: 1279px) {
   .catalog-groups {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 992px) {
+  body.docked .page-columns,
+  body.docked.fullcontent .page-columns,
+  body.docked.listing .page-columns {
+    grid-template-columns:
+      [screen-start] 1.5em
+      [screen-start-inset page-start] minmax(50px, 100px)
+      [page-start-inset] 50px
+      [body-start-outset] 50px
+      [body-start] 1.5em
+      [body-content-start] minmax(500px, calc(1400px - 3em))
+      [body-content-end] 1.5em
+      [body-end] 50px
+      [body-end-outset] minmax(50px, 100px)
+      [page-end-inset] 50px
+      [page-end] 5fr
+      [screen-end-inset] 1.5em
+      [screen-end];
+  }
+
+  body.docked.fullcontent .page-columns {
+    grid-template-columns:
+      [screen-start] 1.5em
+      [screen-start-inset page-start] minmax(50px, 100px)
+      [page-start-inset] 50px
+      [body-start-outset] 50px
+      [body-start] 1.5em
+      [body-content-start] minmax(500px, calc(1400px - 3em))
+      [body-content-end] 1.5em
+      [body-end body-end-outset page-end-inset page-end] 5fr
+      [screen-end-inset] 1.5em
+      [screen-end];
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1355,16 +1355,16 @@ a[href^="https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/"]::aft
   body.docked.listing .page-columns {
     grid-template-columns:
       [screen-start] 1.5em
-      [screen-start-inset page-start] minmax(50px, 100px)
-      [page-start-inset] 50px
-      [body-start-outset] 50px
+      [screen-start-inset page-start] minmax(24px, 100px)
+      [page-start-inset] clamp(16px, 2vw, 50px)
+      [body-start-outset] clamp(16px, 2vw, 50px)
       [body-start] 1.5em
-      [body-content-start] minmax(500px, calc(1400px - 3em))
+      [body-content-start] minmax(500px, 1fr)
       [body-content-end] 1.5em
-      [body-end] 50px
-      [body-end-outset] minmax(50px, 100px)
-      [page-end-inset] 50px
-      [page-end] 5fr
+      [body-end] clamp(16px, 2vw, 50px)
+      [body-end-outset] minmax(24px, 100px)
+      [page-end-inset] clamp(16px, 2vw, 50px)
+      [page-end] 0px
       [screen-end-inset] 1.5em
       [screen-end];
   }
@@ -1372,13 +1372,13 @@ a[href^="https://github.com/OSU-BMBL/BMBL-analysis-notebooks/tree/master/"]::aft
   body.docked.fullcontent .page-columns {
     grid-template-columns:
       [screen-start] 1.5em
-      [screen-start-inset page-start] minmax(50px, 100px)
-      [page-start-inset] 50px
-      [body-start-outset] 50px
+      [screen-start-inset page-start] minmax(24px, 100px)
+      [page-start-inset] clamp(16px, 2vw, 50px)
+      [body-start-outset] clamp(16px, 2vw, 50px)
       [body-start] 1.5em
-      [body-content-start] minmax(500px, calc(1400px - 3em))
+      [body-content-start] minmax(500px, 1fr)
       [body-content-end] 1.5em
-      [body-end body-end-outset page-end-inset page-end] 5fr
+      [body-end body-end-outset page-end-inset page-end] minmax(24px, 100px)
       [screen-end-inset] 1.5em
       [screen-end];
   }


### PR DESCRIPTION
## Summary

This PR is an ongoing site-quality pass for the BMBL Quarto website.

It begins with a responsiveness and layout bugfix sweep and is intended to stay open briefly for additional small site bugfixes and design improvements.

## Included so far

- fixed the main content layout so pages use available screen width more effectively on desktop
- fixed the blank-space issue that reappeared when zooming out to larger effective widths
- fixed horizontal overflow issues on mobile caused by wide code blocks and long inline code
- improved Quarto docked-layout behavior so the desktop content track keeps expanding instead of hitting an early width cap
- preserved existing navigation and search behavior while updating the layout rules

## Root issues addressed

This PR fixes two related layout bugs:

1. The site previously stopped using available width too early on desktop, leaving large blank gutters.
2. The issue appeared partially fixed at moderate zoom levels but came back again when zooming out further because the docked Quarto grid still had a second-stage width cap.

## Verification

- rendered the site locally with `quarto render`
- tested the local preview in-browser
- confirmed all rendered pages fit at mobile width without horizontal overflow
- confirmed the homepage and workflow pages continue expanding at larger desktop widths instead of re-capping early
- confirmed sidebar navigation and search overlay still work after the layout changes

## Notes

This PR is intentionally suitable for a short series of follow-up commits.

Planned or possible follow-up commits in this PR:
- additional site bugfixes found during audit
- edge-case layout polish
- small readability and navigation improvements
- additional responsive refinements across workflow pages

## Scope guardrails

This PR is limited to site UX, responsiveness, and presentation-layer fixes.
It does not change workflow scientific content or analysis logic.