### PR TITLE
Harden scrna-seurat-preprocess reference execution

### DIFF
--- a/skills/scrna-seurat-preprocess/SKILL.md
+++ b/skills/scrna-seurat-preprocess/SKILL.md
@@ -27,18 +27,22 @@ create `cell_type` labels or run per-cell-type DEG here.
 ## Inputs and outputs
 
 - **Inputs:** two raw integer 10x directories, each with `barcodes.tsv.gz`,
-  `features.tsv.gz`, and `matrix.mtx.gz`; no upstream object is required.
+  `features.tsv.gz`, and `matrix.mtx.gz`; features must use committed human-style
+  gene symbols containing mitochondrial `MT-` and ribosomal `RP[SL][0-9]` names.
+  Mouse-style or ID-keyed feature annotations are not supported by this skill's QC.
 - **Example inputs:** `scRNAseq_general_workflow/data/ctrl_raw_feature_bc_matrix/` and
   `scRNAseq_general_workflow/data/stim_raw_feature_bc_matrix/`.
 - **Pilot boundary:** this runner accepts exactly one `ctrl` and one `stim` directory;
   it does not generalize to additional samples or conditions.
+- **Layer policy:** the runner joins the merged RNA layers before normalization so the
+  Seurat v5 preprocessing path matches `scRNAseq_general_workflow/1_preprocess.rmd`.
 
 | Artifact | Contents |
 |---|---|
-| `combined_qc.rds` | QC-filtered Seurat object with RNA counts, PCA, UMAP, and `seurat_clusters` |
+| `combined_qc.rds` | QC-filtered Seurat object with post-merge joined RNA counts, PCA, UMAP, and `seurat_clusters` |
 | `qc_summary.csv` | Per-sample and total input, selected, and QC-passing cell counts |
-| `markers.csv` | Positive per-cluster markers from `FindAllMarkers()` after `JoinLayers()` |
-| `run_manifest.txt` | Input paths, branch, selected/input counts, QC thresholds, and seed |
+| `markers.csv` | Positive per-cluster markers from `FindAllMarkers()` after post-merge `JoinLayers()` |
+| `run_manifest.txt` | Input paths, branch, post-merge layer policy, selected/input counts, QC thresholds, and seed |
 | `sessionInfo.txt` | Exact R and package versions used for the run |
 
 ## Choose a branch
@@ -62,6 +66,11 @@ Rscript skills/scrna-seurat-preprocess/scripts/run.R \
 
 `--out` must name a new or empty directory; the runner rejects non-empty
 directories so validation cannot mix a failed run with stale artifacts.
+The `reference_subset` branch rejects `--subset-barcodes-per-sample` values below
+`100` before reading either matrix. This is only an input floor: after QC, the runner
+also requires at least `31` cells and `31` usable/variable RNA features before the
+fixed 30-PC procedure and confirms that PCA produced all 30 dimensions. It fails with
+an actionable error rather than adapting dimensions for low-information inputs.
 
 Run the bundled validator; its successful internal checks are the completion evidence:
 
@@ -102,3 +111,5 @@ some barcodes with at least 200 detected features.
 | Gotcha | What happens / fix |
 |---|---|
 | `Warning: Some cell names are duplicated across objects provided. Renaming to enforce unique cell names.` | Observed when control and stimulation inputs reused barcode names. `run.R` assigns the fixed role labels `ctrl` and `stim` to `project`, `orig.ident`, and merge `add.cell.ids`, so names remain unique even when both directories are named `raw_feature_bc_matrix`. |
+| `ERROR: Sample 'ctrl' has no mitochondrial features matching ^MT-. ... mouse-style or ID-keyed features are not supported.` | Observed with a disposable 10x fixture lacking `MT-` names. The runner fails before QC instead of silently assigning zero mitochondrial or ribosomal percentages; provide human-style gene symbols containing both required patterns. |
+| `ERROR: Fixed 30-PC preprocessing requires at least 31 QC-passing cells after filtering; found 30.` | Observed with a disposable 100-barcode fixture that retained only 15 cells per sample after filtering. The `100`-barcode input floor does not guarantee post-QC PCA readiness; provide inputs that retain at least 31 cells and 31 usable/variable RNA features, because this skill intentionally does not adapt its fixed 30-PC procedure. |

--- a/skills/scrna-seurat-preprocess/evals/preprocess.md
+++ b/skills/scrna-seurat-preprocess/evals/preprocess.md
@@ -20,30 +20,31 @@ artifact paths. Use explicit paths and the bundled scripts.
 Fresh Pi execution session command:
 
 ```bash
-pi --provider cation --model gpt-5.4 --approve --no-session \
+pi --mode json --provider cation --model gpt-5.4 --approve --no-session \
   --skill ./skills/scrna-seurat-preprocess/SKILL.md \
-  -p "Run the default reference_subset branch now with the bundled scripts and explicit committed input paths. Use the output directory results/scrna-seurat-preprocess-pi-reference-v8, then run the validator and report only the exact run command, validator command/result, branch, selected/input barcode counts, post-QC counts, cluster count, and artifact paths. Do not perform annotation or per-cell-type DEG."
+  -p "Run the default reference_subset branch now with the bundled scripts and explicit committed input paths. Use the output directory results/scrna-seurat-preprocess-issue33-pi-reference-v2, then run the validator and report only the exact run command, validator command/result, branch, layer policy, selected/input barcode counts, post-QC counts, cluster count, and artifact paths. Do not perform annotation or per-cell-type DEG."
 ```
 
 That session created the required artifacts in
-`results/scrna-seurat-preprocess-pi-reference-v8`. The terminal wrapper detached
+`results/scrna-seurat-preprocess-issue33-pi-reference-v2`. The terminal wrapper detached
 before returning its prose response, so the evaluation does not reconstruct one.
 Instead, a second fresh Pi session verified the exact output in JSON mode:
 
 ```bash
 pi --mode json --provider cation --model gpt-5.4 --approve --no-session \
   --skill ./skills/scrna-seurat-preprocess/SKILL.md \
-  -p "Validate results/scrna-seurat-preprocess-pi-reference-v8 using the bundled validator. Report the exact validator command/result, execution branch, selected/input barcode counts, post-QC counts, cluster count, and artifact paths. Do not claim full-data completion."
+  -p "Run only this command and report its output exactly: Rscript skills/scrna-seurat-preprocess/scripts/validate_output.R --out results/scrna-seurat-preprocess-issue33-pi-reference-v2"
 ```
 
 Pi verification response (JSON mode):
 
 ```text
-Validation passed for /Users/jonathanyang/Documents/BMBL-analysis-notebooks-phase2/results/scrna-seurat-preprocess-pi-reference-v8 (branch=reference_subset; ctrl selected/input=20000/737280; ctrl post-QC=14957; stim selected/input=20000/737280; stim post-QC=14983; clusters=21)
+Validation passed for /Users/jonathanyang/Documents/BMBL-analysis-notebooks-phase2/results/scrna-seurat-preprocess-issue33-pi-reference-v2 (branch=reference_subset; ctrl selected/input=20000/737280; ctrl post-QC=14957; stim selected/input=20000/737280; stim post-QC=14983; clusters=21)
 ```
 
 The output directory contains `combined_qc.rds`, `qc_summary.csv`, `markers.csv`,
-`run_manifest.txt`, and `sessionInfo.txt`. This is validated evidence for the
+`run_manifest.txt`, and `sessionInfo.txt`; its manifest records
+`layer_policy: joined_immediately_after_merge`. This is validated evidence for the
 `reference_subset` branch only, not a claim of `full_data` completion.
 
 ## Judgment

--- a/skills/scrna-seurat-preprocess/evals/reference-run-evidence.md
+++ b/skills/scrna-seurat-preprocess/evals/reference-run-evidence.md
@@ -8,32 +8,40 @@ RDS and CSV artifacts remain ignored under `results/`.
     Rscript skills/scrna-seurat-preprocess/scripts/run.R \
       --ctrl scRNAseq_general_workflow/data/ctrl_raw_feature_bc_matrix \
       --stim scRNAseq_general_workflow/data/stim_raw_feature_bc_matrix \
-      --out results/scrna-seurat-preprocess-pi-reference-v8
+      --out results/scrna-seurat-preprocess-issue33-pca-preflight-v2
 
 ## Validation command and exact log
 
     Rscript skills/scrna-seurat-preprocess/scripts/validate_output.R \
-      --out results/scrna-seurat-preprocess-pi-reference-v8
+      --out results/scrna-seurat-preprocess-issue33-pca-preflight-v2
 
-    Validation passed for /Users/jonathanyang/Documents/BMBL-analysis-notebooks-phase2/results/scrna-seurat-preprocess-pi-reference-v8 (branch=reference_subset; ctrl selected/input=20000/737280; ctrl post-QC=14957; stim selected/input=20000/737280; stim post-QC=14983; clusters=21)
+    Validation passed for /Users/jonathanyang/Documents/BMBL-analysis-notebooks-phase2/results/scrna-seurat-preprocess-issue33-pca-preflight-v2 (branch=reference_subset; ctrl selected/input=20000/737280; ctrl post-QC=14957; stim selected/input=20000/737280; stim post-QC=14983; clusters=21)
 
 The branch-specific result is complete as a validated deterministic reference run: it
 demonstrates that the procedure works and its required artifacts are internally valid.
+Its manifest records `layer_policy: joined_immediately_after_merge`, matching the
+recorded source workflow before normalization.
 For these committed inputs, the subset cut is not binding: the `20000`-barcode cap
 captures all 15,325 control and 15,277 stimulation barcodes with at least 200 detected
 features. Because the cut is not binding, both branches build the object from the
 same barcodes and therefore share one `min.cells = 3` gene universe: 15,397 genes for
 control and 15,153 for stimulation, a branch delta of 0.
 
-The run recorded above predates that correction. It was produced while the runner
-measured the full-input gene universe across all 737,280 raw barcodes, which counted
-genes detected only in empty droplets and reported the branch delta as 60 (control)
-and 111 (stimulation). Its barcode, post-QC, and cluster counts are unaffected.
-
 The validated output retains 14,957 control and 14,983 stimulation post-QC cells in
 21 clusters. The manifest records `ctrl_subset_cut_binding: FALSE` and
 `stim_subset_cut_binding: FALSE`; future inputs that exceed the real-cell subset
 capacity emit `TRUE` and a runner warning.
+
+## Fixed-dimension readiness check
+
+A disposable human-symbol 10x fixture supplied the minimum 100 input barcodes but
+retained only 15 QC-passing cells per sample. The runner exited before normalization,
+variable-feature selection, or PCA with:
+
+    ERROR: Fixed 30-PC preprocessing requires at least 31 QC-passing cells after filtering; found 30. Increase the selected barcodes or use inputs that retain enough cells under the documented QC policy.
+
+This confirms that `100` is an input floor rather than a claim of post-QC dimensional
+readiness. The fixture was temporary and is not tracked.
 
 ## sessionInfo.txt contents
 

--- a/skills/scrna-seurat-preprocess/evals/verify-artifacts.md
+++ b/skills/scrna-seurat-preprocess/evals/verify-artifacts.md
@@ -3,7 +3,7 @@
 ## Prompt
 
 ```text
-Verify that results/scrna-seurat-preprocess-pi-reference-v8 is a validated
+Verify that results/scrna-seurat-preprocess-issue33-pi-reference-v2 is a validated
 reference_subset scrna-seurat-preprocess output directory. Do not trust filenames
 alone; run the bundled validator and report the branch and selected/input barcode
 counts.
@@ -22,26 +22,27 @@ Fresh Pi session command:
 ```bash
 pi --mode json --provider cation --model gpt-5.4 --approve --no-session \
   --skill ./skills/scrna-seurat-preprocess/SKILL.md \
-  -p "Verify that results/scrna-seurat-preprocess-pi-reference-v8 is a validated reference_subset scrna-seurat-preprocess output directory. Do not trust filenames alone; run only the bundled validator and report the branch, selected/input barcode counts, post-QC counts, and cluster count."
+  -p "Run only this command and report its output exactly: Rscript skills/scrna-seurat-preprocess/scripts/validate_output.R --out results/scrna-seurat-preprocess-issue33-pi-reference-v2"
 ```
 
 Pi response (JSON mode):
 
 ```text
-Validation passed for /Users/jonathanyang/Documents/BMBL-analysis-notebooks-phase2/results/scrna-seurat-preprocess-pi-reference-v8 (branch=reference_subset; ctrl selected/input=20000/737280; ctrl post-QC=14957; stim selected/input=20000/737280; stim post-QC=14983; clusters=21)
+Validation passed for /Users/jonathanyang/Documents/BMBL-analysis-notebooks-phase2/results/scrna-seurat-preprocess-issue33-pi-reference-v2 (branch=reference_subset; ctrl selected/input=20000/737280; ctrl post-QC=14957; stim selected/input=20000/737280; stim post-QC=14983; clusters=21)
 ```
 
 The command run was:
 
 ```bash
 Rscript skills/scrna-seurat-preprocess/scripts/validate_output.R \
-  --out results/scrna-seurat-preprocess-pi-reference-v8
+  --out results/scrna-seurat-preprocess-issue33-pi-reference-v2
 ```
 
 The reported evidence is
 `reference_subset`, `20000/737280` selected/input barcodes for both samples, 14,957
-control and 14,983 stimulation post-QC cells, and 21 clusters. Thus the output is
-validated by internal checks, not filenames alone.
+control and 14,983 stimulation post-QC cells, and 21 clusters. Its manifest also
+records `layer_policy: joined_immediately_after_merge`. Thus the output is validated
+by internal checks, not filenames alone.
 
 ## Judgment
 

--- a/skills/scrna-seurat-preprocess/scripts/run.R
+++ b/skills/scrna-seurat-preprocess/scripts/run.R
@@ -5,6 +5,10 @@ fail <- function(message, status = 1L) {
   quit(save = "no", status = status)
 }
 
+minimum_reference_subset_barcodes <- 100L
+fixed_pca_dimensions <- 30L
+minimum_fixed_pca_inputs <- fixed_pca_dimensions + 1L
+
 parse_args <- function(args) {
   parsed <- list(
     ctrl = NULL,
@@ -69,6 +73,17 @@ parse_args <- function(args) {
       paste(
         "Missing required arguments:",
         paste(names(missing_required)[missing_required], collapse = ", ")
+      )
+    )
+  }
+  if (!parsed$full_run &&
+      parsed$subset_barcodes_per_sample < minimum_reference_subset_barcodes) {
+    fail(
+      paste0(
+        "--subset-barcodes-per-sample must be at least ",
+        minimum_reference_subset_barcodes,
+        " for the reference_subset branch so the fixed 30-PC workflow has a ",
+        "safe input floor; use --full-run for complete-matrix processing."
       )
     )
   }
@@ -155,15 +170,104 @@ genes_with_min_cells <- function(matrix, min_cells = 3L) {
   rownames(matrix)[Matrix::rowSums(matrix > 0) >= min_cells]
 }
 
-calc_percent_ribo <- function(object) {
-  ribo_genes <- rownames(object)[grep("^RP[SL][[:digit:]]", rownames(object))]
-  if (length(ribo_genes) == 0L) {
-    rep(0, ncol(object))
-  } else {
-    ribo_counts <- Matrix::colSums(LayerData(object[ribo_genes, ], assay = "RNA", layer = "counts"))
-    total_counts <- Matrix::colSums(LayerData(object, assay = "RNA", layer = "counts"))
-    as.numeric(ribo_counts / total_counts * 100)
+require_human_qc_features <- function(object, sample_label) {
+  feature_names <- rownames(object)
+  mito_genes <- feature_names[grep("^MT-", feature_names)]
+  ribo_genes <- feature_names[grep("^RP[SL][[:digit:]]", feature_names)]
+  missing <- c(
+    if (length(mito_genes) == 0L) "mitochondrial features matching ^MT-",
+    if (length(ribo_genes) == 0L) "ribosomal features matching ^RP[SL][[:digit:]]"
+  )
+  if (length(missing) > 0L) {
+    fail(
+      paste0(
+        "Sample '", sample_label, "' has no ", paste(missing, collapse = " or "),
+        ". scrna-seurat-preprocess requires committed human-style gene symbols ",
+        "(for example MT-CO1 and RPL3) for QC; mouse-style or ID-keyed features ",
+        "are not supported."
+      )
+    )
   }
+  list(mito_genes = mito_genes, ribo_genes = ribo_genes)
+}
+
+calc_percent_ribo <- function(object, ribo_genes) {
+  ribo_counts <- Matrix::colSums(LayerData(object[ribo_genes, ], assay = "RNA", layer = "counts"))
+  total_counts <- Matrix::colSums(LayerData(object, assay = "RNA", layer = "counts"))
+  as.numeric(ribo_counts / total_counts * 100)
+}
+
+require_fixed_pca_cell_count <- function(object) {
+  qc_cell_count <- ncol(object)
+  if (qc_cell_count < minimum_fixed_pca_inputs) {
+    fail(
+      paste0(
+        "Fixed ", fixed_pca_dimensions, "-PC preprocessing requires at least ",
+        minimum_fixed_pca_inputs, " QC-passing cells after filtering; found ",
+        qc_cell_count, ". Increase the selected barcodes or use inputs that retain ",
+        "enough cells under the documented QC policy."
+      )
+    )
+  }
+}
+
+require_fixed_pca_features <- function(object) {
+  normalized_data <- LayerData(object, assay = "RNA", layer = "data")
+  feature_means <- Matrix::rowMeans(normalized_data)
+  feature_variances <- pmax(
+    Matrix::rowSums(normalized_data * normalized_data) / ncol(normalized_data) - feature_means^2,
+    0
+  )
+  usable_feature_count <- sum(feature_variances > 1e-12)
+  if (usable_feature_count < minimum_fixed_pca_inputs) {
+    fail(
+      paste0(
+        "Fixed ", fixed_pca_dimensions, "-PC preprocessing requires at least ",
+        minimum_fixed_pca_inputs, " normalized RNA features with nonzero variance; found ",
+        usable_feature_count, ". This skill does not adapt PCA dimensions for low-information inputs."
+      )
+    )
+  }
+}
+
+require_fixed_pca_variable_features <- function(object) {
+  variable_feature_count <- length(VariableFeatures(object, assay = "RNA"))
+  if (variable_feature_count < minimum_fixed_pca_inputs) {
+    fail(
+      paste0(
+        "Fixed ", fixed_pca_dimensions, "-PC preprocessing requires at least ",
+        minimum_fixed_pca_inputs, " variable RNA features; found ",
+        variable_feature_count, ". This skill does not adapt PCA dimensions for low-information inputs."
+      )
+    )
+  }
+}
+
+run_fixed_pca <- function(object, seed) {
+  pca_object <- tryCatch(
+    RunPCA(object, npcs = fixed_pca_dimensions, verbose = FALSE, seed.use = seed),
+    error = function(error) {
+      fail(
+        paste0(
+          "Fixed ", fixed_pca_dimensions,
+          "-PC preprocessing could not compute the required PCA reduction after QC: ",
+          conditionMessage(error),
+          ". This skill does not adapt dimensions for low-information inputs."
+        )
+      )
+    }
+  )
+  pca_dimensions <- ncol(Embeddings(pca_object, reduction = "pca"))
+  if (pca_dimensions < fixed_pca_dimensions) {
+    fail(
+      paste0(
+        "Fixed ", fixed_pca_dimensions, "-PC preprocessing produced only ",
+        pca_dimensions, " PCA dimensions after QC. This skill does not adapt dimensions ",
+        "for low-information inputs."
+      )
+    )
+  }
+  pca_object
 }
 
 ensure_package_versions <- function() {
@@ -260,7 +364,8 @@ for (sample_name in names(sample_specs)) {
   # holds the sub-threshold barcodes CreateSeuratObject has just dropped.
   reference_gene_sets[[sample_name]] <- rownames(object)
 
-  object$percent.ribo <- calc_percent_ribo(object)
+  qc_features <- require_human_qc_features(object, spec$label)
+  object$percent.ribo <- calc_percent_ribo(object, qc_features$ribo_genes)
   object <- PercentageFeatureSet(object, "^MT-", col.name = "percent.mito")
 
   sample_objects[[sample_name]] <- object
@@ -283,6 +388,9 @@ combined <- merge(
   add.cell.ids = vapply(sample_specs, function(spec) spec$label, character(1)),
   merge.data = TRUE
 )
+# Match the recorded source workflow: preprocessing starts from one RNA layer,
+# rather than per-sample layers with Seurat v5 layer-wise feature ranking.
+combined <- JoinLayers(combined)
 gene_universe_summary <- lapply(names(sample_specs), function(sample_name) {
   reference_gene_universe <- length(reference_gene_sets[[sample_name]])
   full_input_gene_universe <- length(full_input_gene_sets[[sample_name]])
@@ -319,18 +427,19 @@ combined_qc <- subset(
     nCount_RNA < qc_thresholds$nCount_RNA_max
 )
 
+require_fixed_pca_cell_count(combined_qc)
 DefaultAssay(combined_qc) <- "RNA"
 combined_qc <- NormalizeData(combined_qc, verbose = FALSE)
+require_fixed_pca_features(combined_qc)
 combined_qc <- FindVariableFeatures(combined_qc, nfeatures = 2000, verbose = FALSE)
+require_fixed_pca_variable_features(combined_qc)
 combined_qc <- ScaleData(combined_qc, verbose = FALSE)
-combined_qc <- RunPCA(combined_qc, npcs = 30, verbose = FALSE, seed.use = args$seed)
-combined_qc <- FindNeighbors(combined_qc, dims = 1:30, verbose = FALSE)
+combined_qc <- run_fixed_pca(combined_qc, seed = args$seed)
+combined_qc <- FindNeighbors(combined_qc, dims = seq_len(fixed_pca_dimensions), verbose = FALSE)
 combined_qc <- FindClusters(combined_qc, resolution = 0.8, verbose = FALSE, random.seed = args$seed)
-combined_qc <- RunUMAP(combined_qc, dims = 1:30, verbose = FALSE, seed.use = args$seed)
+combined_qc <- RunUMAP(combined_qc, dims = seq_len(fixed_pca_dimensions), verbose = FALSE, seed.use = args$seed)
 
-# Seurat v5 marker finding needs joined layers after preprocessing and before
-# FindAllMarkers(), or marker output can fail or be incomplete.
-combined_qc <- JoinLayers(combined_qc)
+# Layers were joined immediately after merge to match the source workflow.
 markers <- FindAllMarkers(combined_qc, only.pos = TRUE, min.pct = 0.25, verbose = FALSE)
 # FindAllMarkers() already carries the symbol in `gene`. Its rownames are
 # make.unique()d, so a gene marking several clusters appears there as GENE.1,
@@ -372,6 +481,7 @@ manifest_lines <- c(
   paste("stim_dir:", stim_dir),
   paste("out_dir:", out_dir),
   paste("execution_branch:", if (args$full_run) "full_data" else "reference_subset"),
+  paste("layer_policy:", "joined_immediately_after_merge"),
   paste(
     "completion_criterion:",
     if (args$full_run) {

--- a/skills/scrna-seurat-preprocess/scripts/validate_output.R
+++ b/skills/scrna-seurat-preprocess/scripts/validate_output.R
@@ -174,6 +174,26 @@ if (!is.null(markers)) {
   if (nrow(markers) == 0L) {
     record_failure("markers.csv has no rows")
   }
+  if (inherits(combined, "Seurat") && "gene" %in% colnames(markers)) {
+    marker_genes <- trimws(as.character(markers$gene))
+    marker_genes <- unique(marker_genes[!is.na(marker_genes) & nzchar(marker_genes)])
+    rna_features <- tryCatch(
+      Features(combined, assay = "RNA"),
+      error = function(error) {
+        record_failure(paste("Saved Seurat object RNA feature names are unavailable:", conditionMessage(error)))
+        character()
+      }
+    )
+    unknown_marker_genes <- setdiff(marker_genes, rna_features)
+    if (length(unknown_marker_genes) > 0L) {
+      record_failure(
+        paste(
+          "markers.csv contains non-empty gene values absent from the saved RNA assay:",
+          paste(utils::head(unknown_marker_genes, 10L), collapse = ", ")
+        )
+      )
+    }
+  }
 }
 
 manifest_lines <- readLines(file.path(args, "run_manifest.txt"), warn = FALSE)


### PR DESCRIPTION
## Summary

Closes #33 by hardening `scrna-seurat-preprocess` while preserving its narrow paired raw-10x, fixed 30-PC preprocessing scope.

- Joins Seurat layers immediately after merging `ctrl` and `stim`, matching `scRNAseq_general_workflow/1_preprocess.rmd`.
- Fails closed when either sample lacks human-style mitochondrial (`^MT-`) or ribosomal (`^RP[SL][[:digit:]]`) gene symbols required for QC.
- Requires at least 100 requested barcodes for `reference_subset`, then verifies post-QC readiness for the fixed 30-PC procedure:
  - at least 31 QC-passing cells;
  - at least 31 normalized nonzero-variance RNA features;
  - at least 31 variable features;
  - all 30 PCA embeddings produced before neighbors and UMAP.
- Validates every non-empty `markers.csv$gene` value against the saved RNA assay feature names.
- Updates the skill contract, gotchas, Pi evaluation records, and tracked runtime evidence.

## Validation

- `Rscript skills/scrna-seurat-preprocess/scripts/run.R --help`
- `Rscript skills/scrna-seurat-preprocess/scripts/validate_output.R --help`
- `pi --skill ./skills/scrna-seurat-preprocess/SKILL.md`
- `Rscript validate_repo.R`
- `git diff --check`
- Fresh reference run and validator:
  - output: `results/scrna-seurat-preprocess-issue33-pca-preflight-v2`
  - branch: `reference_subset`
  - selected/input barcodes: `20000/737280` for both `ctrl` and `stim`
  - post-QC cells: `14957` ctrl, `14983` stim
  - clusters: `21`
  - PCA embeddings: `30`
- Negative checks:
  - `<100` requested reference subset exits before input reading.
  - Disposable fixtures missing mitochondrial or ribosomal human-symbol features exit with actionable QC-convention errors.
  - A disposable 100-barcode fixture retaining only 30 paired QC-passing cells exits before PCA with the fixed-dimension readiness error.
  - A copied `markers.csv` containing an unknown non-empty gene exits non-zero in the validator.

## Scope

This skill still ends with QC-filtered clustering, UMAP, and marker artifacts. It does not perform annotation, label transfer, integration, or per-cell-type DEG.